### PR TITLE
Limit exit code to 255 even if errant file length exceeds that

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,7 +14,7 @@ try {
     var files = Object.keys(analysis_1);
     console.log(files.length + " module" + (files.length == 1 ? '' : 's') + " with unused exports");
     files.forEach(function (path) { return console.log(path + ": " + analysis_1[path].join(', ')); });
-    process.exit(files.length);
+    process.exit(Math.min(255, files.length));
 }
 catch (e) {
     console.error(e);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,7 +40,7 @@ try {
 
   files.forEach(path => console.log(`${path}: ${analysis[path].join(', ')}`));
 
-  process.exit(files.length);
+  process.exit(Math.min(255, files.length));
 } catch (e) {
   console.error(e);
   process.exit(-1);


### PR DESCRIPTION
Exit codes are a single byte so anything greater than 255 is going to be modula 256. This patch caps the exit code at 255 so if you have 1000 errant files then you'll still just get 255 as the exit code.

Otherwise if you have an exact multiple of 256 it'll incorrectly return a success exit code:

```sh
$ node -e 'process.exit(256)' ; echo $?
0
```
