### PR TITLE
Add support for export statements

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -38,6 +38,12 @@ var extractImport = function (decl) {
         what: importDefault.concat(importStar, importNames)
     };
 };
+var extractExportStatement = function (decl) {
+    return decl.exportClause
+        ? decl.exportClause.elements
+            .map(function (e) { return (e.propertyName || e.name).text; })
+        : [];
+};
 var extractExportFromImport = function (decl) {
     var moduleSpecifier = decl.moduleSpecifier, exportClause = decl.exportClause;
     if (!moduleSpecifier)
@@ -118,18 +124,24 @@ var mapFile = function (rootDir, path, file, baseUrl) {
             return;
         }
         if (kind === ts.SyntaxKind.ExportDeclaration) {
-            var fw = extractExportFromImport(node);
-            var key = addImport(fw);
-            if (key) {
-                var what = fw.what;
-                if (what == star) {
-                    exports.push("*:" + key);
-                }
-                else {
-                    exports = exports.concat(what);
-                }
+            if (node.moduleSpecifier === undefined) {
+                exports.push.apply(exports, extractExportStatement(node));
+                return;
             }
-            return;
+            else {
+                var fw = extractExportFromImport(node);
+                var key = addImport(fw);
+                if (key) {
+                    var what = fw.what;
+                    if (what == star) {
+                        exports.push("*:" + key);
+                    }
+                    else {
+                        exports = exports.concat(what);
+                    }
+                }
+                return;
+            }
         }
         if (hasModifier(node, ts.SyntaxKind.ExportKeyword)) {
             var decl = node;

--- a/spec/app-spec.js
+++ b/spec/app-spec.js
@@ -9,6 +9,6 @@ describe('app', () => {
 
   it('recurses into imports', () => {
     const analysis = app(join(__dirname, 'data/tsconfig-single-file.json'));
-    expect(analysis.exports).toEqual([ 'b', 'c', 'd', 'default' ]);
+    expect(analysis.exports).toEqual([ 'b', 'c', 'd', 'e', 'default' ]);
   });
 });

--- a/spec/data/exports.ts
+++ b/spec/data/exports.ts
@@ -6,4 +6,8 @@ export function c() { return 2; };
 
 export const d = () => 3;
 
+const e = () => 5;
+
+export { e };
+
 export default 4;

--- a/spec/data/import-e.ts
+++ b/spec/data/import-e.ts
@@ -1,0 +1,1 @@
+import { e } from './exports'; // tslint:disable-line

--- a/spec/data/mod-dir-ts/exports.ts
+++ b/spec/data/mod-dir-ts/exports.ts
@@ -6,4 +6,8 @@ export function c() { return 2; };
 
 export const d = () => 3;
 
+const e = () => 5;
+
+export { e };
+
 export default 4;

--- a/spec/data/mod-dir-tsx/exports.tsx
+++ b/spec/data/mod-dir-tsx/exports.tsx
@@ -6,4 +6,8 @@ export function c() { return 2; };
 
 export const d = () => 3;
 
+const e = () => 5;
+
+export { e };
+
 export default 4;

--- a/spec/import-spec.js
+++ b/spec/import-spec.js
@@ -15,22 +15,23 @@ describe('analyze', () => {
   const itIs = (what, paths, expected) =>
     it(`handles import ${what}`, () => { test1(paths, expected); });
 
-  itIs('nothing', []                       , [ 'a', 'b', 'c', 'd', 'default' ]);
-  itIs('default', ['./import-default.ts']  , [ 'a', 'b', 'c', 'd' ]);
-  itIs('a'      , ['./import-a.ts']        , [ 'b', 'c', 'd', 'default' ]);
-  itIs('b'      , ['./import-b.ts']        , [ 'a', 'c', 'd', 'default' ]);
-  itIs('c'      , ['./import-c.ts']        , [ 'a', 'b', 'd', 'default' ]);
-  itIs('d'      , ['./import-d.ts']        , [ 'a', 'b', 'c', 'default' ]);
+  itIs('nothing', []                       , [ 'a', 'b', 'c', 'd', 'e', 'default' ]);
+  itIs('default', ['./import-default.ts']  , [ 'a', 'b', 'c', 'd', 'e' ]);
+  itIs('a'      , ['./import-a.ts']        , [ 'b', 'c', 'd', 'e', 'default' ]);
+  itIs('b'      , ['./import-b.ts']        , [ 'a', 'c', 'd', 'e', 'default' ]);
+  itIs('c'      , ['./import-c.ts']        , [ 'a', 'b', 'd', 'e', 'default' ]);
+  itIs('d'      , ['./import-d.ts']        , [ 'a', 'b', 'c', 'e', 'default' ]);
+  itIs('e'      , ['./import-e.ts']        , [ 'a', 'b', 'c', 'd', 'default' ]);
   itIs('*'      , ['./import-star.ts']     , [ 'default' ]);
   itIs('all'    , ['./import-star.ts'
                   ,'./import-default.ts'], undefined);
-  itIs('non-ts' , ['./import-other.ts']    , [ 'b', 'c', 'd', 'default' ]);
+  itIs('non-ts' , ['./import-other.ts']    , [ 'b', 'c', 'd', 'e', 'default' ]);
 
   it('handles export * from', () => {
     const result = testExports(['./import-export-star.ts']);
 
     expect(result['exports']).toEqual(['default']);
-    expect(result['import-export-star']).toEqual([ 'a', 'b', 'c', 'd' ]);
+    expect(result['import-export-star']).toEqual([ 'a', 'b', 'c', 'd', 'e' ]);
   });
 
   it('handles import from directory index', () => {
@@ -91,11 +92,11 @@ describe('analyze', () => {
 
     itIs('value',
       ['./import-a-with-base-url.ts'],
-      ['b', 'c', 'd', 'default']
+      ['b', 'c', 'd', 'e', 'default']
     );
     itIs('default',
       ['./import-default-with-base-url.ts'],
-      ['a', 'b', 'c', 'd']
+      ['a', 'b', 'c', 'd', 'e']
     );
   });
 });


### PR DESCRIPTION
The current implementation asumes all export declarations are used only
for reexporting things from other modules (export-from-import). Export
declarations are also used to export things declared in the same module.
This pattern is called [Export Statements](https://www.typescriptlang.org/docs/handbook/modules.html#export-statements).

This PR adds support for export-statements, so that they are not
ignored by ts-unused-exports.

Feel free to rewrite everything to your taste. 