### PR TITLE
Add comment flag to ignore some exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,10 @@ or, in a more generic way:
 ```shell
 ./bin/ts-unused-exports example/tsconfig.json $(cd example; find -name '*.ts')
 ```
+
+You can use comment flags to ignore exports:
+
+```ts
+// ts-unused-exports:disable-next-line
+export function add2(x:number) { return x + 2; }
+```

--- a/example/math.ts
+++ b/example/math.ts
@@ -1,3 +1,6 @@
 export function add1(x:number) { return x + 1; }
 
+// ts-unused-exports:disable-next-line
+export function add2(x:number) { return x + 2; }
+
 export default (x:number) => x + 1;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -114,6 +114,16 @@ var mapFile = function (rootDir, path, file, baseUrl) {
         return key;
     };
     ts.forEachChild(file, function (node) {
+        var comments = ts.getLeadingCommentRanges(file.getFullText(), node.getFullStart());
+        if (comments) {
+            var commentRange = comments[comments.length - 1];
+            var commentText = file
+                .getFullText()
+                .substring(commentRange.pos, commentRange.end);
+            if (commentText === '// ts-unused-exports:disable-next-line') {
+                return;
+            }
+        }
         var kind = node.kind;
         if (kind === ts.SyntaxKind.ImportDeclaration) {
             addImport(extractImport(node));

--- a/spec/data/exports.ts
+++ b/spec/data/exports.ts
@@ -10,4 +10,7 @@ const e = () => 5;
 
 export { e };
 
+// ts-unused-exports:disable-next-line
+export const f = 1;
+
 export default 4;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -135,6 +135,21 @@ const mapFile = (
   };
 
   ts.forEachChild(file, (node:ts.Node) => {
+    const comments = ts.getLeadingCommentRanges(
+      file.getFullText(),
+      node.getFullStart()
+    );
+
+    if (comments) {
+      const commentRange = comments[comments.length - 1];
+      const commentText = file
+        .getFullText()
+        .substring(commentRange.pos, commentRange.end);
+      if (commentText === '// ts-unused-exports:disable-next-line') {
+        return;
+      }
+    }
+
     const { kind } = node;
 
     if (kind === ts.SyntaxKind.ImportDeclaration) {


### PR DESCRIPTION
This PR adds a comment flag to ignore certain exports just like the TSLint comment flags. 

```ts
// ts-unused-exports:disable-next-line
export function add2(x:number) { return x + 2; }
```