### PR TITLE
Add cmd line option to ignore results from some file paths

### DIFF
--- a/lib/ArgsParser.d.ts
+++ b/lib/ArgsParser.d.ts
@@ -1,0 +1,7 @@
+import { ExtraCommandLineOptions } from "./types";
+export declare type TsFilesAndOptions = {
+    tsFiles?: string[];
+    options: ExtraCommandLineOptions;
+};
+declare const _default: (files?: string[] | undefined) => TsFilesAndOptions;
+export default _default;

--- a/lib/ArgsParser.js
+++ b/lib/ArgsParser.js
@@ -1,0 +1,46 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function extractOptionsFromFiles(files) {
+    var filesAndOptions = {
+        tsFiles: undefined,
+        options: {}
+    };
+    var isOption = function (opt) {
+        return opt.indexOf("--") === 0;
+    };
+    if (files) {
+        var options = files.filter(function (f) { return isOption(f); });
+        filesAndOptions.tsFiles = files.filter(function (f) { return !isOption(f); });
+        return processOptions(filesAndOptions, options);
+    }
+    return filesAndOptions;
+}
+function processOptions(filesAndOptions, options) {
+    var newFilesAndOptions = {
+        options: {
+            pathsToIgnore: []
+        },
+        tsFiles: filesAndOptions.tsFiles
+    };
+    options.forEach(function (option) {
+        var parts = option.split("=");
+        var optionName = parts[0];
+        var optionValue = parts[1];
+        switch (optionName) {
+            case "--ignorePaths":
+                {
+                    var paths = optionValue.split(";");
+                    paths.forEach(function (path) {
+                        newFilesAndOptions.options.pathsToIgnore.push(path);
+                    });
+                }
+                break;
+            default:
+                throw new Error("Not a recognised option '" + optionName + "'");
+        }
+    });
+    return newFilesAndOptions;
+}
+exports.default = (function (files) {
+    return extractOptionsFromFiles(files);
+});

--- a/lib/app.js
+++ b/lib/app.js
@@ -5,6 +5,7 @@ var ts = require("typescript");
 var path_1 = require("path");
 var parser_1 = require("./parser");
 var analyzer_1 = require("./analyzer");
+var ArgsParser_1 = require("./ArgsParser");
 var parseTsConfig = function (tsconfigPath) {
     var basePath = path_1.resolve(path_1.dirname(tsconfigPath));
     try {
@@ -30,6 +31,7 @@ var loadTsConfig = function (tsconfigPath, explicitFiles) {
     return { baseUrl: baseUrl, files: explicitFiles || files };
 };
 exports.default = (function (tsconfigPath, files) {
-    var tsConfig = loadTsConfig(tsconfigPath, files);
-    return analyzer_1.default(parser_1.default(path_1.dirname(tsconfigPath), tsConfig.files, tsConfig.baseUrl));
+    var args = ArgsParser_1.default(files);
+    var tsConfig = loadTsConfig(tsconfigPath, args.tsFiles);
+    return analyzer_1.default(parser_1.default(path_1.dirname(tsconfigPath), tsConfig.files, tsConfig.baseUrl, args.options));
 });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,7 +4,7 @@ var app_1 = require("./app");
 var fs_1 = require("fs");
 var _a = process.argv.slice(2), tsconfig = _a[0], tsFiles = _a.slice(1);
 if (!tsconfig || !fs_1.existsSync(tsconfig) || !fs_1.statSync(tsconfig).isFile()) {
-    console.error("\n  usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts]\n\n  Note: if no file is specified after tsconfig, the files will be read from the\n  tsconfig's \"files\" key which must be present.\n\n  If the files are specified, their path must be relative to the tsconfig file.\n  For example, given:\n    /\n    |-- config\n    |    -- tsconfig.json\n    -- src\n         -- file.ts\n\n  Then the usage would be:\n    ts-unused-exports config/tsconfig.json ../src/file.ts\n  ");
+    console.error("\n  usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--ignorePaths=path1;path2]\n\n  Note: if no file is specified after tsconfig, the files will be read from the\n  tsconfig's \"files\" key which must be present.\n\n  If the files are specified, their path must be relative to the tsconfig file.\n  For example, given:\n    /\n    |-- config\n    |    -- tsconfig.json\n    -- src\n         -- file.ts\n\n  Then the usage would be:\n    ts-unused-exports config/tsconfig.json ../src/file.ts\n  ");
     process.exit(-1);
 }
 try {

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -4,6 +4,7 @@ var fs_1 = require("fs");
 var fs_2 = require("fs");
 var path_1 = require("path");
 var parser_1 = require("./parser");
+var ArgsParser_1 = require("./ArgsParser");
 var getFileMap = function (files) {
     var map = {};
     files.map(function (f) { return map[f.path] = f; });
@@ -31,22 +32,23 @@ function analyzeFile(fileMap, file, analysis) {
     return dep;
 }
 ;
-var analyzeDeps = function (tsconfigPath) {
-    var files = parser_1.default(path_1.dirname(tsconfigPath), JSON.parse(fs_1.readFileSync(tsconfigPath, { encoding: 'utf8' })).files);
+var analyzeDeps = function (tsconfigPath, extraOptions) {
+    var files = parser_1.default(path_1.dirname(tsconfigPath), JSON.parse(fs_1.readFileSync(tsconfigPath, { encoding: 'utf8' })).files, undefined, extraOptions);
     var fileMap = getFileMap(files);
     var analysis = {};
     files.forEach(function (f) { return analyzeFile(fileMap, f, analysis); });
     return analysis;
 };
-var _a = process.argv.slice(2), tsconfig = _a[0], filter = _a[1];
+var _a = process.argv.slice(2), tsconfig = _a[0], filter = _a[1], options = _a.slice(2);
 if (!tsconfig || !fs_2.existsSync(tsconfig) || !fs_2.statSync(tsconfig).isFile()) {
-    console.error("usage: deps path/to/tsconfig.json [filter]");
+    console.error("usage: deps path/to/tsconfig.json [filter] [--ignorePaths=path1;path2]");
     process.exit(-1);
 }
 var getValues = function (o) {
     return Object.keys(o).reduce(function (v, k) { return v.concat([o[k]]); }, []);
 };
-var analysis = analyzeDeps(tsconfig);
+var parsedOptions = ArgsParser_1.default(options).options;
+var analysis = analyzeDeps(tsconfig, parsedOptions);
 var deps = getValues(analysis);
 deps.sort(function (a, b) { return a.depth - b.depth; });
 console.log(deps.length + " modules found");

--- a/lib/parser.d.ts
+++ b/lib/parser.d.ts
@@ -1,3 +1,3 @@
-import { File } from './types';
-declare const _default: (rootDir: string, paths: string[], baseUrl?: string | undefined) => File[];
+import { File, ExtraCommandLineOptions } from './types';
+declare const _default: (rootDir: string, paths: string[], baseUrl?: string | undefined, extraOptions?: ExtraCommandLineOptions | undefined) => File[];
 export default _default;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -191,7 +191,7 @@ var resolvePath = function (rootDir) { return function (path) {
     throw "Cannot find module '" + path + "'.\n  I've tried the following paths and none of them works:\n  - " + tsPath + "\n  - " + tsxPath + "\n  - " + tsIndexPath + "\n  - " + tsxIndexPath + "\n  - " + jsPath + "\n  - " + path + " (only to skip it later)\n  ";
 }; };
 var notNull = function (v) { return v !== null; };
-var parsePaths = function (rootDir, paths, baseUrl, otherFiles) {
+var parsePaths = function (rootDir, paths, baseUrl, otherFiles, extraOptions) {
     var _a;
     var files = otherFiles.concat(paths
         .filter(function (p) { return p.indexOf('.d.') == -1; })
@@ -202,9 +202,17 @@ var parsePaths = function (rootDir, paths, baseUrl, otherFiles) {
         .map(resolvePath(rootDir))
         .filter(notNull);
     return missingImports.length
-        ? parsePaths(rootDir, missingImports, baseUrl, files)
-        : files;
+        ? parsePaths(rootDir, missingImports, baseUrl, files, extraOptions)
+        : files.filter(function (f) { return !shouldPathBeIgnored(f.path, extraOptions.pathsToIgnore); });
 };
-exports.default = (function (rootDir, paths, baseUrl) {
-    return parsePaths(rootDir, paths, baseUrl, []);
+// Allow disabling of results, by path from command line (useful for large projects)
+var shouldPathBeIgnored = function (path, pathsToIgnore) {
+    if (!pathsToIgnore) {
+        return false;
+    }
+    return pathsToIgnore.some(function (ignore) { return path.indexOf(ignore) >= 0; });
+};
+exports.default = (function (rootDir, paths, baseUrl, extraOptions) {
+    var activeExtraOptions = extraOptions || {};
+    return parsePaths(rootDir, paths, baseUrl, [], activeExtraOptions);
 });

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -9,3 +9,6 @@ export interface File {
 export interface Analysis {
     [index: string]: string[];
 }
+export interface ExtraCommandLineOptions {
+    pathsToIgnore?: string[];
+}

--- a/spec/import-spec.js
+++ b/spec/import-spec.js
@@ -1,9 +1,13 @@
 const { join } = require('path');
 const parseFiles = require('../lib/parser').default;
 const analyzeFiles = require('../lib/analyzer').default;
+const extractOptionsFromFiles= require('../lib/ArgsParser').default;
 
-const testWith = (paths, baseUrl) =>
-  analyzeFiles(parseFiles('./spec/data', paths, baseUrl));
+const testWith = (paths, baseUrl) => {
+  const tsFilesAndOptions = extractOptionsFromFiles(paths);
+
+  return analyzeFiles(parseFiles('./spec/data', tsFilesAndOptions.tsFiles, baseUrl, tsFilesAndOptions.options));
+};
 const testExports = (paths) => testWith(['./exports.ts'].concat(paths));
 const test1 = (paths, expected) => expect(
     testExports(paths)['exports']
@@ -17,6 +21,11 @@ describe('analyze', () => {
 
   itIs('nothing', []                       , [ 'a', 'b', 'c', 'd', 'e', 'default' ]);
   itIs('default', ['./import-default.ts']  , [ 'a', 'b', 'c', 'd', 'e' ]);
+
+  // Test ignoring results for some paths:
+  itIs('ignored', ['./import-default.ts', '--ignorePaths=exports;other-1'], undefined);
+  itIs('not ignored', ['./import-default.ts', '--ignorePaths=other-1;other-2'], [ 'a', 'b', 'c', 'd', 'e' ]);
+
   itIs('a'      , ['./import-a.ts']        , [ 'b', 'c', 'd', 'e', 'default' ]);
   itIs('b'      , ['./import-b.ts']        , [ 'a', 'c', 'd', 'e', 'default' ]);
   itIs('c'      , ['./import-c.ts']        , [ 'a', 'b', 'd', 'e', 'default' ]);

--- a/src/ArgsParser.ts
+++ b/src/ArgsParser.ts
@@ -1,6 +1,6 @@
 import { ExtraCommandLineOptions } from "./types";
 
-export type TsFilesAndOptions = {
+type TsFilesAndOptions = {
   tsFiles?: string[];
   options: ExtraCommandLineOptions;
 };

--- a/src/ArgsParser.ts
+++ b/src/ArgsParser.ts
@@ -17,7 +17,10 @@ function extractOptionsFromFiles(files?: string[]): TsFilesAndOptions {
 
     if (files) {
         const options = files.filter(f => isOption(f));
-        filesAndOptions.tsFiles = files.filter(f => !isOption(f));
+
+        const filteredFiles = files.filter(f => !isOption(f))
+
+        filesAndOptions.tsFiles = filteredFiles.length ? filteredFiles : undefined;
 
         return processOptions(filesAndOptions, options);
     }

--- a/src/ArgsParser.ts
+++ b/src/ArgsParser.ts
@@ -1,0 +1,63 @@
+import { ExtraCommandLineOptions } from "./types";
+
+export type TsFilesAndOptions = {
+  tsFiles?: string[];
+  options: ExtraCommandLineOptions;
+};
+
+function extractOptionsFromFiles(files?: string[]): TsFilesAndOptions {
+    const filesAndOptions: TsFilesAndOptions = {
+        tsFiles: undefined,
+        options: {}
+    };
+
+    const isOption = (opt: string): boolean => {
+        return opt.indexOf("--") === 0;
+    };
+
+    if (files) {
+        const options = files.filter(f => isOption(f));
+        filesAndOptions.tsFiles = files.filter(f => !isOption(f));
+
+        return processOptions(filesAndOptions, options);
+    }
+
+    return filesAndOptions;
+}
+
+function processOptions(
+    filesAndOptions: TsFilesAndOptions,
+    options: string[]
+): TsFilesAndOptions {
+    const newFilesAndOptions: TsFilesAndOptions = {
+        options: {
+        pathsToIgnore: []
+    },
+    tsFiles: filesAndOptions.tsFiles
+    };
+
+options.forEach(option => {
+    const parts = option.split("=");
+    const optionName = parts[0];
+    const optionValue = parts[1];
+
+    switch (optionName) {
+    case "--ignorePaths":
+        {
+        const paths = optionValue.split(";");
+        paths.forEach(path => {
+            newFilesAndOptions.options.pathsToIgnore!.push(path);
+        });
+        }
+        break;
+    default:
+        throw new Error(`Not a recognised option '${optionName}'`);
+    }
+});
+
+return newFilesAndOptions;
+}
+
+export default (files?:string[]): TsFilesAndOptions => {
+    return extractOptionsFromFiles(files);
+};  

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import * as ts from 'typescript';
 import { dirname, resolve } from 'path';
 import parseFiles from './parser';
 import analyze, { Analysis } from './analyzer';
+import extractOptionsFromFiles from './ArgsParser';
 
 const parseTsConfig = (tsconfigPath:string) => {
   const basePath = resolve(dirname(tsconfigPath));
@@ -47,12 +48,15 @@ const loadTsConfig = (
 };
 
 export default (tsconfigPath:string, files?:string[]): Analysis => {
-  const tsConfig = loadTsConfig(tsconfigPath, files);
+  const args = extractOptionsFromFiles(files);
+  const tsConfig = loadTsConfig(tsconfigPath, args.tsFiles);
+
   return analyze(
     parseFiles(
       dirname(tsconfigPath),
       tsConfig.files,
-      tsConfig.baseUrl
+      tsConfig.baseUrl,
+      args.options
     )
   );
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ const [tsconfig, ...tsFiles] = process.argv.slice(2);
 
 if (!tsconfig || !existsSync(tsconfig) || !statSync(tsconfig).isFile()) {
   console.error(`
-  usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts]
+  usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--ignorePaths=path1;path2]
 
   Note: if no file is specified after tsconfig, the files will be read from the
   tsconfig's "files" key which must be present.

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,3 +11,7 @@ export interface File {
 export interface Analysis {
   [index:string]:string[]
 }
+
+export interface ExtraCommandLineOptions {
+  pathsToIgnore?: string[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "./src/cli.ts",
     "./src/deps.ts",
     "./src/parser.ts",
+    "./src/ArgsParser.ts",
     "./src/types.ts"
   ]
 }


### PR DESCRIPTION
Here is a PR to ignore results from some file paths.

The idea is to be able to exclude parts of a large project, without having to add `// tslint:disable` type comments.

note: I need this feature myself, for scanning a large codebase which is raising some false positives, and also I need a way to restrict the scan to some areas.

Let me know if it is useful, or needs improvement.