### PR TITLE
Fix the ignorePaths option and add a test example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 
 ### Changed
+- Fix the --ignorePaths option (it was incorrectly filtering the parsed files, instead of filtering the output)
 
 ## [2.1.0] - 20 Oct 2019
 ### Added

--- a/example/tsx/package-lock.json
+++ b/example/tsx/package-lock.json
@@ -2,11 +2,6 @@
     "requires": true,
     "lockfileVersion": 1,
     "dependencies": {
-        "@types/json5": {
-            "version": "0.0.29",
-            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
-        },
         "@types/prop-types": {
             "version": "15.7.3",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -21,64 +16,15 @@
                 "csstype": "^2.2.0"
             }
         },
-        "ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "requires": {
-                "color-convert": "^1.9.0"
-            }
-        },
-        "chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            }
-        },
-        "color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "requires": {
-                "color-name": "1.1.3"
-            }
-        },
-        "color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
         "csstype": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
             "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ=="
         },
-        "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-        },
-        "json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-            "requires": {
-                "minimist": "^1.2.0"
-            }
         },
         "loose-envify": {
             "version": "1.4.0",
@@ -87,11 +33,6 @@
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
-        },
-        "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "object-assign": {
             "version": "4.1.1",
@@ -122,51 +63,6 @@
             "version": "16.10.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
             "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
-        },
-        "strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        },
-        "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "requires": {
-                "has-flag": "^3.0.0"
-            }
-        },
-        "ts-unused-exports": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ts-unused-exports/-/ts-unused-exports-2.1.0.tgz",
-            "integrity": "sha512-gs3XxyISlxjbTne0eV60g1hwSrpcbLzhYljnN5RInzJ1XsgfcGwCX0Fnpaps26/D8HNbbU4hWbENQnBGno9Ffg==",
-            "requires": {
-                "chalk": "^2.4.1",
-                "strip-json-comments": "^2.0.1",
-                "tsconfig-paths": "^3.5.0",
-                "typescript": "^2.9.2"
-            }
-        },
-        "tsconfig-paths": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-            "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-            "requires": {
-                "@types/json5": "^0.0.29",
-                "json5": "^1.0.1",
-                "minimist": "^1.2.0",
-                "strip-bom": "^3.0.0"
-            }
-        },
-        "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
         }
     }
 }

--- a/example/with-paths/app.ts
+++ b/example/with-paths/app.ts
@@ -1,0 +1,3 @@
+import inc from './math';
+
+console.log('two', inc(1));

--- a/example/with-paths/math.ts
+++ b/example/with-paths/math.ts
@@ -1,0 +1,8 @@
+import { calculations } from "utils";
+
+export function add1(x: number) { return calculations.sum(x, 1); }
+
+// ts-unused-exports:disable-next-line
+export function add2(x: number) { return x + 2; }
+
+export default (x: number) => x + 1;

--- a/example/with-paths/package-lock.json
+++ b/example/with-paths/package-lock.json
@@ -1,0 +1,11 @@
+{
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "typescript": {
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+            "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
+        }
+    }
+}

--- a/example/with-paths/package.json
+++ b/example/with-paths/package.json
@@ -6,10 +6,10 @@
     },
     "license": "MIT",
     "scripts": {
-        "test": "npm i && ../../bin/ts-unused-exports ./tsconfig.json"
+        "build": "tsc",
+        "test": "npm i && npm run build && ../../bin/ts-unused-exports ./tsconfig.json --ignorePaths=to-ignore"
     },
     "dependencies": {
-        "@types/react": "^16.4.18",
-        "react": "^16.6.0"
+        "typescript": "^3.6.4"
     }
 }

--- a/example/with-paths/tsconfig.json
+++ b/example/with-paths/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es5",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+    "paths": {
+      "utils": ["utils/src"],
+      "utils/*": ["utils/src/*"]
+    }
+  }
+}

--- a/example/with-paths/utils/src/calculations.ts
+++ b/example/with-paths/utils/src/calculations.ts
@@ -1,0 +1,3 @@
+export namespace calculations {
+    export const sum = (a: number, b: number) => a + b;
+}

--- a/example/with-paths/utils/src/index.ts
+++ b/example/with-paths/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./calculations";

--- a/example/with-paths/utils/src/to-ignore.ts
+++ b/example/with-paths/utils/src/to-ignore.ts
@@ -1,0 +1,2 @@
+// Should be ignored due to --ignorePaths option
+export const unused_fun = () => 0;

--- a/ispec/_run-and-check-exit-code.sh
+++ b/ispec/_run-and-check-exit-code.sh
@@ -1,6 +1,6 @@
 # continue on error
 set +e;
-node ../../bin/ts-unused-exports tsconfig.json --exitWithCount
+node ../../bin/ts-unused-exports tsconfig.json --exitWithCount --ignorePaths=to-ignore
 ERROR_COUNT=$?
 if [ $ERROR_COUNT -ne 1 ]
 then 

--- a/ispec/run.sh
+++ b/ispec/run.sh
@@ -7,3 +7,7 @@ popd
 pushd ../example/tsx
 npm i > /dev/null && ../../ispec/_run-and-check-exit-code.sh
 popd
+
+pushd ../example/with-paths
+npm i > /dev/null && ../../ispec/_run-and-check-exit-code.sh
+popd

--- a/spec/import-spec.js
+++ b/spec/import-spec.js
@@ -6,7 +6,7 @@ const { extractOptionsFromFiles } = require('../lib/argsParser');
 const analyzePaths = (files, baseUrl) => {
   const tsFilesAndOptions = extractOptionsFromFiles(files);
 
-  return analyzeFiles(parseFiles('./spec/data', { files: tsFilesAndOptions.tsFiles, baseUrl: baseUrl }, tsFilesAndOptions.options))
+  return analyzeFiles(parseFiles('./spec/data', { files: tsFilesAndOptions.tsFiles, baseUrl: baseUrl }), tsFilesAndOptions.options)
 };
 const testWithResults = (...args) => {
   const result = analyzePaths(...args);
@@ -25,8 +25,9 @@ describe('analyze', () => {
   itIs('default', ['./import-default.ts'], ['a', 'b', 'c', 'd', 'e']);
 
   // Test ignoring results for some paths:
-  itIs('nothing', ['./import-default.ts', '--ignorePaths=exports;other-1'], []);
-  itIs('default', ['./import-default.ts', '--ignorePaths=other-1;other-2'], ['a', 'b', 'c', 'd', 'e']);
+  itIs('ignorePaths - all ignored', ['./import-default.ts', '--ignorePaths=exports;other-1'], []);
+  itIs('ignorePaths - none ignored', ['./import-default.ts', '--ignorePaths=other-1;other-2'], ['a','b','c','d','e']);
+  itIs('ignorePaths - default', ['./import-default.ts', '--ignorePaths=other-1;other-2'], ['a', 'b', 'c', 'd', 'e']);
 
   itIs('a', ['./import-a.ts'], ['b', 'c', 'd', 'e', 'default']);
   itIs('b', ['./import-b.ts'], ['a', 'c', 'd', 'e', 'default']);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,12 @@
-import { readFileSync } from 'fs';
 import * as ts from 'typescript';
+
+import analyze, { Analysis } from './analyzer';
 import { dirname, resolve } from 'path';
 
-import parseFiles from './parser';
-import analyze, { Analysis } from './analyzer';
 import { TsConfig } from './types';
 import { extractOptionsFromFiles } from './argsParser';
+import parseFiles from './parser';
+import { readFileSync } from 'fs';
 
 const parseTsConfig = (tsconfigPath: string) => {
   const basePath = resolve(dirname(tsconfigPath));
@@ -59,8 +60,8 @@ export default (tsconfigPath: string, files?: string[]): Analysis => {
   return analyze(
     parseFiles(
       dirname(tsconfigPath),
-      tsConfig,
-      args.options
-    )
+      tsConfig
+    ),
+    args.options
   );
 };

--- a/src/argsParser.ts
+++ b/src/argsParser.ts
@@ -4,7 +4,7 @@ import { ExtraCommandLineOptions } from "./types";
 
 type TsFilesAndOptions = {
     tsFiles?: string[];
-    options: ExtraCommandLineOptions;
+    options?: ExtraCommandLineOptions;
 };
 
 function canExtractOptionsFromFiles(files?: string[]): boolean {
@@ -56,13 +56,13 @@ function processOptions(
 
         switch (optionName) {
             case "--exitWithCount":
-                newFilesAndOptions.options.exitWithCount = true;
+                newFilesAndOptions.options!.exitWithCount = true;
                 break;
             case "--ignorePaths":
                 {
                     const paths = optionValue.split(";");
                     paths.forEach(path => {
-                        newFilesAndOptions.options.pathsToIgnore!.push(path);
+                        newFilesAndOptions.options!.pathsToIgnore!.push(path);
                     });
                 }
                 break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,8 @@
-import chalk from 'chalk';
+import { extractOptionsFromFiles, hasValidArgs } from './argsParser';
 
 import analyzeTsConfig from './app';
+import chalk from 'chalk';
 import { showUsage } from './usage';
-import { hasValidArgs, extractOptionsFromFiles } from './argsParser';
 
 const [tsconfig, ...tsFiles] = process.argv.slice(2);
 
@@ -27,7 +27,8 @@ try {
 
   files.forEach(path => console.log(`${path}: ${chalk.bold.yellow(analysis[path].join(", "))}`));
 
-  if (extractOptionsFromFiles(tsFiles).options.exitWithCount) {
+  const options = extractOptionsFromFiles(tsFiles).options;
+  if (options && options.exitWithCount) {
     process.exit(files.length);
   }
 } catch (e) {

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,9 +1,9 @@
-import { dirname } from 'path';
-
-import { loadTsConfig } from './app';
+import { ExtraCommandLineOptions, File } from './types';
 import { extractOptionsFromFiles, hasValidArgs } from './argsParser';
+
+import { dirname } from 'path';
+import { loadTsConfig } from './app';
 import parseFiles from './parser';
-import { File, ExtraCommandLineOptions } from './types';
 import { showUsage } from './usage';
 
 interface FileMap {
@@ -65,9 +65,9 @@ function analyzeFile(
   return dep;
 };
 
-const analyzeDeps = (tsconfigPath: string, extraOptions: ExtraCommandLineOptions) => {
+const analyzeDeps = (tsconfigPath: string): DepAnalysis => {
   const tsConfig = loadTsConfig(tsconfigPath);
-  const files = parseFiles(dirname(tsconfigPath), tsConfig, extraOptions);
+  const files = parseFiles(dirname(tsconfigPath), tsConfig);
   const fileMap = getFileMap(files);
 
   const analysis: DepAnalysis = {};
@@ -77,7 +77,8 @@ const analyzeDeps = (tsconfigPath: string, extraOptions: ExtraCommandLineOptions
   return analysis;
 };
 
-const [tsconfig, filter, ...options] = process.argv.slice(2);
+// Not using options here
+const [tsconfig, filter] = process.argv.slice(2);
 
 if (!hasValidArgs()) {
   showUsage();
@@ -90,9 +91,7 @@ const getValues = (o: DepAnalysis) =>
     []
   );
 
-const parsedOptions = extractOptionsFromFiles(options).options;
-
-const analysis = analyzeDeps(tsconfig, parsedOptions);
+const analysis = analyzeDeps(tsconfig);
 const deps = getValues(analysis);
 deps.sort((a, b) => a.depth - b.depth);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import * as tsconfigPaths from 'tsconfig-paths';
 
-import { ExtraCommandLineOptions, File, Imports, TsConfig, TsConfigPaths } from './types';
+import { File, Imports, TsConfig, TsConfigPaths } from './types';
 import { dirname, join, relative, resolve, sep } from 'path';
 import { existsSync, readFileSync } from 'fs';
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,8 +1,9 @@
-import { existsSync, readFileSync } from 'fs';
-import { dirname, resolve, relative, join, sep } from 'path';
 import * as ts from 'typescript';
 import * as tsconfigPaths from 'tsconfig-paths';
-import { File, TsConfig, TsConfigPaths, Imports, ExtraCommandLineOptions } from './types';
+
+import { ExtraCommandLineOptions, File, Imports, TsConfig, TsConfigPaths } from './types';
+import { dirname, join, relative, resolve, sep } from 'path';
+import { existsSync, readFileSync } from 'fs';
 
 const TRIM_QUOTES = /^['"](.*)['"]$/;
 
@@ -250,27 +251,15 @@ const parseFile = (
 
 const parsePaths = (
   rootDir: string,
-  { baseUrl, files: filePaths, paths }: TsConfig,
-  extraOptions: ExtraCommandLineOptions
+  { baseUrl, files: filePaths, paths }: TsConfig
 ): File[] => {
   const files = filePaths
-    .filter(p => p.indexOf('.d.') == -1 && !shouldPathBeIgnored(p, extraOptions.pathsToIgnore))
+    .filter(p => p.indexOf('.d.') == -1)
     .map(path => parseFile(rootDir, resolve(rootDir, path), baseUrl, paths));
 
   return files;
-};
-
-// Allow disabling of results, by path from command line (useful for large projects)
-const shouldPathBeIgnored = (path: string, pathsToIgnore?: string[]) => {
-  if (!pathsToIgnore) {
-    return false;
-  }
-
-  return pathsToIgnore.some(ignore => path.indexOf(ignore) >= 0);
 }
 
-export default (rootDir: string, TsConfig: TsConfig, extraOptions?: ExtraCommandLineOptions): File[] => {
-  const activeExtraOptions = extraOptions || {};
-
-  return parsePaths(rootDir, TsConfig, activeExtraOptions);
+export default (rootDir: string, TsConfig: TsConfig): File[] => {
+  return parsePaths(rootDir, TsConfig);
 };


### PR DESCRIPTION
- Fix the ignorePaths option #55 (it was filtering the parsed files, instead of filtering the end-results)
- Add a test example, that is executed as part of the itests

- Also includes a fix for the `tsx` example