### PR TITLE
Show locations in files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased] - ReleaseDate
 ### Added
+- If the option --showLineNumber is given, then output 1 line per unused export, with the location in the file (line number, column)
 
 ### Changed
 - Fix the --ignorePaths option (it was incorrectly filtering the parsed files, instead of filtering the output)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Options:
 |---|---|---|
 | `ignorePaths` | Exclude files that match the given path segments. | `--ignorePaths=math;utils` |
 | `exitWithCount` | Set the process exit code to be the count of files that have unused exports. | `--exitWithCount` |
+| `showLineNumber` | Show the line number and column of the unused export. | `--showLineNumber` |
 
 Note that if `ts-unused-exports` is called without files, the files will be read from the tsconfig's `files` or `include` key which must be present. If called with files, then those file paths should be relative to the `tsconfig.json`, just like you would specifie them in your tsconfig's `files` key.
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Options:
 
 | Option name | Description  | Example |
 |---|---|---|
-| `ignorePaths` | Exclude files that match the given path segments. | `--ignorePaths=math;utils` |
 | `exitWithCount` | Set the process exit code to be the count of files that have unused exports. | `--exitWithCount` |
+| `ignorePaths` | Exclude files that match the given path segments. | `--ignorePaths=math;utils` |
 | `showLineNumber` | Show the line number and column of the unused export. | `--showLineNumber` |
 
 Note that if `ts-unused-exports` is called without files, the files will be read from the tsconfig's `files` or `include` key which must be present. If called with files, then those file paths should be relative to the `tsconfig.json`, just like you would specifie them in your tsconfig's `files` key.

--- a/ispec/_run-and-check-exit-code.sh
+++ b/ispec/_run-and-check-exit-code.sh
@@ -1,11 +1,16 @@
 # continue on error
 set +e;
-node ../../bin/ts-unused-exports tsconfig.json --exitWithCount --ignorePaths=to-ignore
-ERROR_COUNT=$?
-if [ $ERROR_COUNT -ne 1 ]
-then 
-    echo "[FAIL] Expected 1 issue, but got {$ERROR_COUNT}."
-else
-    echo "[PASS]."
-    exit 0
-fi
+
+function run {
+    node ../../bin/ts-unused-exports tsconfig.json --exitWithCount --ignorePaths=to-ignore $1
+    ERROR_COUNT=$?
+    if [ $ERROR_COUNT -ne 1 ]
+    then
+        echo "[FAIL] Expected 1 issue, but got {$ERROR_COUNT}."
+    else
+        echo "[PASS]."
+    fi
+}
+
+run
+run --showLineNumber

--- a/spec/app-spec.js
+++ b/spec/app-spec.js
@@ -11,7 +11,6 @@ describe('app', () => {
   it('understands tsconfig include', () => {
     const analysis = getExportsString(app(join(__dirname, 'data/tsconfig-include.json')));
 
-    expect(analysis).toEqual(['a', 'b', 'c', 'd', 'e', 'default']);
+    expect(analysis.map(a => a.exportName)).toEqual(['a', 'b', 'c', 'd', 'e', 'default']);
   });
-
 });

--- a/spec/import-spec.js
+++ b/spec/import-spec.js
@@ -11,7 +11,7 @@ const analyzePaths = (files, baseUrl) => {
 const testWithResults = (...args) => {
   const result = analyzePaths(...args);
 
-  return getExportsString(result);
+  return getExportsString(result).map(e => e.exportName);
 };
 
 const testExports = (paths) => testWithResults(['./exports.ts'].concat(paths));
@@ -26,7 +26,7 @@ describe('analyze', () => {
 
   // Test ignoring results for some paths:
   itIs('ignorePaths - all ignored', ['./import-default.ts', '--ignorePaths=exports;other-1'], []);
-  itIs('ignorePaths - none ignored', ['./import-default.ts', '--ignorePaths=other-1;other-2'], ['a','b','c','d','e']);
+  itIs('ignorePaths - none ignored', ['./import-default.ts', '--ignorePaths=other-1;other-2'], ['a', 'b', 'c', 'd', 'e']);
   itIs('ignorePaths - default', ['./import-default.ts', '--ignorePaths=other-1;other-2'], ['a', 'b', 'c', 'd', 'e']);
 
   itIs('a', ['./import-a.ts'], ['b', 'c', 'd', 'e', 'default']);
@@ -43,8 +43,8 @@ describe('analyze', () => {
     const result = analyzePaths(['./exports.ts', './import-export-star.ts']);
     const keys = Object.keys(result);
 
-    expect(result[keys[0]]).toEqual(['default']);
-    expect(result[keys[1]]).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(result[keys[0]].map(e => e.exportName)).toEqual(['default']);
+    expect(result[keys[1]].map(e => e.exportName)).toEqual(['a', 'b', 'c', 'd', 'e']);
   });
 
   it('handles import from directory index', () => {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -1,4 +1,4 @@
-import { Analysis, ExtraCommandLineOptions, File, Imports } from './types';
+import { Analysis, ExtraCommandLineOptions, File, Imports, LocationInFile } from './types';
 export { Analysis } from './types'
 
 interface FileExport {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -100,6 +100,10 @@ export default (files: File[], extraOptions?: ExtraCommandLineOptions): Analysis
 
     const unusedExports = Object.keys(exports).filter(k => exports[k].usageCount === 0);
 
+    if (unusedExports.length === 0) {
+      return;
+    }
+
     analysis[path] = [];
     unusedExports.forEach(e => {
       analysis[path].push({

--- a/src/argsParser.ts
+++ b/src/argsParser.ts
@@ -66,6 +66,9 @@ function processOptions(
                     });
                 }
                 break;
+            case "--showLineNumber":
+                newFilesAndOptions.options.showLineNumber = true;
+                break;
             default:
                 throw new Error(`Not a recognised option '${optionName}'`);
         }

--- a/src/argsParser.ts
+++ b/src/argsParser.ts
@@ -67,7 +67,7 @@ function processOptions(
                 }
                 break;
             case "--showLineNumber":
-                newFilesAndOptions.options.showLineNumber = true;
+                newFilesAndOptions.options!.showLineNumber = true;
                 break;
             default:
                 throw new Error(`Not a recognised option '${optionName}'`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ try {
       });
     });
   } else {
-    files.forEach(path => console.log(`${path}: ${chalk.bold.yellow(analysis[path].join(", "))}`));
+    files.forEach(path => console.log(`${path}: ${chalk.bold.yellow(analysis[path].map(r => r.exportName).join(", "))}`));
   }
 
   if (options && options.exitWithCount) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,14 +33,17 @@ try {
     return `[${location.line},${location.character}]`;
   };
 
-  // xxx opt
-  files.forEach(path => {
-    analysis[path].forEach(unusedExport => {
-      console.log(`${path}${getLocationInFile(unusedExport.location)}: ${chalk.bold.yellow(unusedExport.exportName)}`);
-    });
-  });
-
   const options = extractOptionsFromFiles(tsFiles).options;
+  if (options && options.showLineNumber) {
+    files.forEach(path => {
+      analysis[path].forEach(unusedExport => {
+        console.log(`${path}${getLocationInFile(unusedExport.location)}: ${chalk.bold.yellow(unusedExport.exportName)}`);
+      });
+    });
+  } else {
+    files.forEach(path => console.log(`${path}: ${chalk.bold.yellow(analysis[path].join(", "))}`));
+  }
+
   if (options && options.exitWithCount) {
     process.exit(files.length);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+import { LocationInFile } from './types';
 import { extractOptionsFromFiles, hasValidArgs } from './argsParser';
 
 import analyzeTsConfig from './app';
@@ -25,7 +26,19 @@ try {
     files.length == 1 ? '' : 's'
     } with unused exports`));
 
-  files.forEach(path => console.log(`${path}: ${chalk.bold.yellow(analysis[path].join(", "))}`));
+  const getLocationInFile = (location: LocationInFile): string => {
+    if (!location) {
+      return "";
+    }
+    return `[${location.line},${location.character}]`;
+  };
+
+  // xxx opt
+  files.forEach(path => {
+    analysis[path].forEach(unusedExport => {
+      console.log(`${path}${getLocationInFile(unusedExport.location)}: ${chalk.bold.yellow(unusedExport.exportName)}`);
+    });
+  });
 
   const options = extractOptionsFromFiles(tsFiles).options;
   if (options && options.exitWithCount) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,4 +40,5 @@ export interface TsConfig {
 export interface ExtraCommandLineOptions {
   exitWithCount?: boolean;
   pathsToIgnore?: string[];
+  showLineNumber?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,11 +6,25 @@ export interface File {
   path: string;
   fullPath: string;
   imports: Imports;
+  // The exported type names
   exports: string[];
+  // The line number and column for each export - Matches the exports array.
+  exportLocations: LocationInFile[];
+}
+
+export interface LocationInFile {
+  /** 1-based. */
+  line: number;
+  character: number;
+}
+
+export interface ExportNameAndLocation {
+  exportName: string;
+  location: LocationInFile;
 }
 
 export interface Analysis {
-  [index: string]: string[];
+  [index: string]: ExportNameAndLocation[];
 }
 
 export interface TsConfigPaths {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,6 +1,6 @@
 export function showUsage() {
   console.error(`
-    usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--exitWithCount][--ignorePaths=path1;path2]
+    usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--exitWithCount][--ignorePaths=path1;path2][--showLineNumber]
   
     Note: if no file is specified after tsconfig, the files will be read from the
     tsconfig's "files" key which must be present.


### PR DESCRIPTION
Add  a command line option to include the location within the file, in the output (#57).

This speeds up finding the unused exports, as the IDE will navigate to the correct line in the file.
