### PR TITLE
Fix bug introduced with showLineNumber option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 
 ### Changed
+- Fix bug introduced by --showLineNumber option, where analysis throws error on more complex projects.
 
 ## [3.0.0] - 27 Oct 2019
 ### Changed

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -43,10 +43,24 @@ const processImports = (imports: Imports, exportMap: ExportMap) => {
   Object.keys(imports).forEach(key => {
     const ex = exportMap[key] && exportMap[key].exports;
     if (!ex) return;
+
+    const addUsage = (imp: string) => {
+      if (!ex[imp]) {
+        ex[imp] = {
+          usageCount: 0,
+          location: {
+            line:1,
+            character: 1
+          }
+        }
+      }
+      ex[imp].usageCount++;
+    };
+
     imports[key].forEach(imp =>
       imp == '*'
-        ? Object.keys(ex).filter(e => e != 'default').forEach(e => ex[e].usageCount++)
-        : ex[imp].usageCount++);
+        ? Object.keys(ex).filter(e => e != 'default').forEach(addUsage)
+        : addUsage(imp));
   });
 };
 


### PR DESCRIPTION
Fixes a bug that was introduced with the `showLineNumber` option.

Issue #61

It was found when using `ts-unused-exports` on a large project.
