### PR TITLE
Add option to include definition files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Add option --includeDeclarationFiles to include `.d.ts` files when searching for unused exports.
+
 ### Changed
 
 ## [4.0.0] - Thu Nov 07 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Add option --includeDeclarationFiles to include `.d.ts` files when searching for unused exports.
+- Include `.d.ts` files when searching for unused exports. This can be disabled via the --excludeDeclarationFiles option.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ const result = analyzeTsConfig('path/to/tsconfig.json');
 
 Options:
 
-| Option name      | Description                                                                  | Example                    |
-| ---------------- | ---------------------------------------------------------------------------- | -------------------------- |
-| `exitWithCount`  | Set the process exit code to be the count of files that have unused exports. | `--exitWithCount`          |
-| `ignorePaths`    | Exclude files that match the given path segments.                            | `--ignorePaths=math;utils` |
-| `showLineNumber` | Show the line number and column of the unused export.                        | `--showLineNumber`         |
+| Option name               | Description                                                                  | Example                     |
+| ------------------------- | ---------------------------------------------------------------------------- | --------------------------- |
+| `exitWithCount`           | Set the process exit code to be the count of files that have unused exports. | `--exitWithCount`           |
+| `ignorePaths`             | Exclude files that match the given path segments.                            | `--ignorePaths=math;utils`  |
+| `includeDeclarationFiles` | Include `.d.ts` files when looking for unused exports.                       | `--includeDeclarationFiles` |
+| `showLineNumber`          | Show the line number and column of the unused export.                        | `--showLineNumber`          |
 
 Note that if `ts-unused-exports` is called without files, the files will be read from the tsconfig's `files` or `include` key which must be present. If called with files, then those file paths should be relative to the `tsconfig.json`, just like you would specify them in your tsconfig's `files` key.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Options:
 | ------------------------- | ---------------------------------------------------------------------------- | --------------------------- |
 | `exitWithCount`           | Set the process exit code to be the count of files that have unused exports. | `--exitWithCount`           |
 | `ignorePaths`             | Exclude files that match the given path segments.                            | `--ignorePaths=math;utils`  |
-| `includeDeclarationFiles` | Include `.d.ts` files when looking for unused exports.                       | `--includeDeclarationFiles` |
+| `excludeDeclarationFiles` | Exclude `.d.ts` files when looking for unused exports.                       | `--excludeDeclarationFiles` |
 | `showLineNumber`          | Show the line number and column of the unused export.                        | `--showLineNumber`          |
 
 Note that if `ts-unused-exports` is called without files, the files will be read from the tsconfig's `files` or `include` key which must be present. If called with files, then those file paths should be relative to the `tsconfig.json`, just like you would specify them in your tsconfig's `files` key.

--- a/features/export-statements.feature
+++ b/features/export-statements.feature
@@ -34,3 +34,45 @@ Scenario: Include files from sub-folder, without error
     """
   When analyzing "tsconfig.json"
   Then the result is { "b.ts": ["a"], "x/a.ts": ["A_unused"] }
+
+Scenario: Include re-exported types from sub-folder, without error
+  Given file "x/a.ts" is
+    """
+    export type A = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is
+    """
+    import { A } from './x/a'
+    export type B_unused = 2;
+    export A;
+    """
+  And file "c.ts" is
+    """
+    import { A } from './b'
+    export type C_unused = 2;
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["B_unused"], "c.ts": ["C_unused"], "x/a.ts": ["A_unused"] }
+
+Scenario: Include files indirectly from sub-folder, without error
+  Given file "x/a.ts" is
+    """
+    export type A1 = 1;
+    export type A2 = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is
+    """
+    import { A1 } from './x/a'
+    export const B_a: A = 0
+    export type B_unused = 2;
+    """
+  And file "c.ts" is
+    """
+    import { A2 } from './x/a'
+    import { B_a } from './b'
+    export type C_unused = 2;
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["B_unused"], "c.ts": ["C_unused"], "x/a.ts": ["A_unused"] }

--- a/features/export-statements.feature
+++ b/features/export-statements.feature
@@ -20,3 +20,17 @@ Scenario: export { a } from file
   And file "c.ts" is import { a } from './b';
   When analyzing "tsconfig.json"
   Then the result is {}
+
+Scenario: Include files from sub-folder, without error
+  Given file "x/a.ts" is
+    """
+    export type A = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is
+    """
+    import { A } from './x/a'
+    export const a: A = 0
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["a"], "x/a.ts": ["A_unused"] }

--- a/features/include-definition-files.feature
+++ b/features/include-definition-files.feature
@@ -10,20 +10,6 @@ Scenario: Do NOT include definition files
   When analyzing "tsconfig.json"
   Then the result is {} 
 
-Scenario: Do NOT include definition files from sub-folder, without error
-  Given file "x/a.d.ts" is
-    """
-    export type A = 1;
-    export type A_unused = 2;
-    """
-  And file "b.ts" is 
-    """
-    import { A } from './x/a'
-    export const a: A = 0
-    """
-  When analyzing "tsconfig.json"
-  Then the result is { "b.ts": ["a"] }
-
 Scenario: Include definition files from sub-folder, without error
   Given file "x/a.d.ts" is 
     """
@@ -37,3 +23,17 @@ Scenario: Include definition files from sub-folder, without error
     """
   When analyzing "tsconfig.json" with files ["--includeDeclarationFiles"]
   Then the result is { "b.ts": ["a"], "x/a.d.ts": ["A", "A_unused"] }
+
+Scenario: Do NOT include definition files from sub-folder, without error
+  Given file "x/a.d.ts" is
+    """
+    export type A = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is 
+    """
+    import { A } from './x/a'
+    export const a: A = 0
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["a"] }

--- a/features/include-definition-files.feature
+++ b/features/include-definition-files.feature
@@ -9,3 +9,31 @@ Scenario: Do NOT include definition files
   Given file "exports.d.ts" is export const unused = 1;
   When analyzing "tsconfig.json"
   Then the result is {} 
+
+Scenario: Do NOT include definition files from sub-folder, without error
+  Given file "x/a.d.ts" is
+    """
+    export type A = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is 
+    """
+    import { A } from './x/a'
+    export const a: A = 0
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["a"] }
+
+Scenario: Include definition files from sub-folder, without error
+  Given file "x/a.d.ts" is 
+    """
+    export type A = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is 
+    """
+    import { A } from './x/a'
+    export const a: A = 0
+    """
+  When analyzing "tsconfig.json" with files ["--includeDeclarationFiles"]
+  Then the result is { "b.ts": ["a"], "x/a.d.ts": ["A", "A_unused"] }

--- a/features/include-definition-files.feature
+++ b/features/include-definition-files.feature
@@ -1,39 +1,80 @@
 Feature: include definition files
 
-  Scenario: Include definition files
-    Given file "exports.d.ts" is export const unused = 1;
-    When analyzing "tsconfig.json"
-    Then the result is { "exports.d.ts": ["unused"] }
+Scenario: Include definition files
+  Given file "exports.d.ts" is export const unused = 1;
+  When analyzing "tsconfig.json"
+  Then the result is { "exports.d.ts": ["unused"] }
 
-  Scenario: Do NOT include definition files
-    Given file "exports.d.ts" is export const unused = 1;
-    When analyzing "tsconfig.json" with files ["--excludeDeclarationFiles"]
-    Then the result is {}
+Scenario: Do NOT include definition files
+  Given file "exports.d.ts" is export const unused = 1;
+  When analyzing "tsconfig.json" with files ["--excludeDeclarationFiles"]
+  Then the result is {}
 
-  Scenario: Include definition files from sub-folder, without error
-    Given file "x/a.d.ts" is
-      """
-      export type A = 1;
-      export type A_unused = 2;
-      """
-    And file "b.ts" is
-      """
-      import { A } from './x/a'
-      export const a: A = 0
-      """
-    When analyzing "tsconfig.json"
-    Then the result is { "b.ts": ["a"], "x/a.d.ts": ["A_unused"] }
+Scenario: Include definition files from sub-folder, without error
+  Given file "x/a.d.ts" is
+    """
+    export type A = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is
+    """
+    import { A } from './x/a'
+    export const a: A = 0
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["a"], "x/a.d.ts": ["A_unused"] }
 
-  Scenario: Do NOT include definition files from sub-folder, without error
-    Given file "x/a.d.ts" is
-      """
-      export type A = 1;
-      export type A_unused = 2;
-      """
-    And file "b.ts" is
-      """
-      import { A } from './x/a'
-      export const a: A = 0
-      """
-    When analyzing "tsconfig.json" with files ["--excludeDeclarationFiles"]
-    Then the result is { "b.ts": ["a"] }
+Scenario: Do NOT include definition files from sub-folder, without error
+  Given file "x/a.d.ts" is
+    """
+    export type A = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is
+    """
+    import { A } from './x/a'
+    export const a: A = 0
+    """
+  When analyzing "tsconfig.json" with files ["--excludeDeclarationFiles"]
+  Then the result is { "b.ts": ["a"] }
+
+Scenario: Include definition files indirectly, from sub-folder, without error
+  Given file "x/a.d.ts" is
+    """
+    export type A = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is
+    """
+    import { A } from './x/a'
+    export const B_a: A = 0
+    export type B = 1
+    export type B_unused = 2
+    """
+  And file "c.ts" is
+    """
+    import { B_a, B } from './b'
+    export type C_unused = 1
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["B_unused"], "c.ts": ["C_unused"], "x/a.d.ts": ["A_unused"] }
+
+Scenario: Include parts of definition files indirectly, from sub-folder, without error
+  Given file "x/a.d.ts" is
+    """
+    export type A1 = 1;
+    export type A2 = 1;
+    export type A_unused = 2;
+    """
+  And file "b.ts" is
+    """
+    import { A1 } from './x/a'
+    export type B_unused = 2
+    """
+  And file "c.ts" is
+    """
+    import { A2 } from './x/a'
+    export type C_unused = 1
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["B_unused"], "c.ts": ["C_unused"], "x/a.d.ts": ["A_unused"] }

--- a/features/include-definition-files.feature
+++ b/features/include-definition-files.feature
@@ -22,7 +22,7 @@ Feature: include definition files
       export const a: A = 0
       """
     When analyzing "tsconfig.json"
-    Then the result is { "b.ts": ["a"], "x/a.d.ts": ["A", "A_unused"] }
+    Then the result is { "b.ts": ["a"], "x/a.d.ts": ["A_unused"] }
 
   Scenario: Do NOT include definition files from sub-folder, without error
     Given file "x/a.d.ts" is

--- a/features/include-definition-files.feature
+++ b/features/include-definition-files.feature
@@ -1,0 +1,11 @@
+Feature: include definition files
+
+Scenario: Include definition files
+  Given file "exports.d.ts" is export const unused = 1;
+  When analyzing "tsconfig.json" with files ["--includeDeclarationFiles"]
+  Then the result is { "exports.d.ts": ["unused"] }
+
+Scenario: Do NOT include definition files
+  Given file "exports.d.ts" is export const unused = 1;
+  When analyzing "tsconfig.json"
+  Then the result is {} 

--- a/features/include-definition-files.feature
+++ b/features/include-definition-files.feature
@@ -1,39 +1,39 @@
 Feature: include definition files
 
-Scenario: Include definition files
-  Given file "exports.d.ts" is export const unused = 1;
-  When analyzing "tsconfig.json" with files ["--includeDeclarationFiles"]
-  Then the result is { "exports.d.ts": ["unused"] }
+  Scenario: Include definition files
+    Given file "exports.d.ts" is export const unused = 1;
+    When analyzing "tsconfig.json"
+    Then the result is { "exports.d.ts": ["unused"] }
 
-Scenario: Do NOT include definition files
-  Given file "exports.d.ts" is export const unused = 1;
-  When analyzing "tsconfig.json"
-  Then the result is {} 
+  Scenario: Do NOT include definition files
+    Given file "exports.d.ts" is export const unused = 1;
+    When analyzing "tsconfig.json" with files ["--excludeDeclarationFiles"]
+    Then the result is {}
 
-Scenario: Include definition files from sub-folder, without error
-  Given file "x/a.d.ts" is 
-    """
-    export type A = 1;
-    export type A_unused = 2;
-    """
-  And file "b.ts" is 
-    """
-    import { A } from './x/a'
-    export const a: A = 0
-    """
-  When analyzing "tsconfig.json" with files ["--includeDeclarationFiles"]
-  Then the result is { "b.ts": ["a"], "x/a.d.ts": ["A", "A_unused"] }
+  Scenario: Include definition files from sub-folder, without error
+    Given file "x/a.d.ts" is
+      """
+      export type A = 1;
+      export type A_unused = 2;
+      """
+    And file "b.ts" is
+      """
+      import { A } from './x/a'
+      export const a: A = 0
+      """
+    When analyzing "tsconfig.json"
+    Then the result is { "b.ts": ["a"], "x/a.d.ts": ["A", "A_unused"] }
 
-Scenario: Do NOT include definition files from sub-folder, without error
-  Given file "x/a.d.ts" is
-    """
-    export type A = 1;
-    export type A_unused = 2;
-    """
-  And file "b.ts" is 
-    """
-    import { A } from './x/a'
-    export const a: A = 0
-    """
-  When analyzing "tsconfig.json"
-  Then the result is { "b.ts": ["a"] }
+  Scenario: Do NOT include definition files from sub-folder, without error
+    Given file "x/a.d.ts" is
+      """
+      export type A = 1;
+      export type A_unused = 2;
+      """
+    And file "b.ts" is
+      """
+      import { A } from './x/a'
+      export const a: A = 0
+      """
+    When analyzing "tsconfig.json" with files ["--excludeDeclarationFiles"]
+    Then the result is { "b.ts": ["a"] }

--- a/src/app.ts
+++ b/src/app.ts
@@ -59,5 +59,8 @@ export default (tsconfigPath: string, files?: string[]): Analysis => {
   const args = extractOptionsFromFiles(files);
   const tsConfig = loadTsConfig(tsconfigPath, args.tsFiles);
 
-  return analyze(parseFiles(dirname(tsconfigPath), tsConfig), args.options);
+  return analyze(
+    parseFiles(dirname(tsconfigPath), tsConfig, args.options),
+    args.options,
+  );
 };

--- a/src/argsParser.ts
+++ b/src/argsParser.ts
@@ -37,8 +37,8 @@ function processOptions(
           });
         }
         break;
-      case '--includeDeclarationFiles':
-        newOptions.includeDeclarationFiles = true;
+      case '--excludeDeclarationFiles':
+        newOptions.excludeDeclarationFiles = true;
         break;
       case '--showLineNumber':
         newOptions.showLineNumber = true;

--- a/src/argsParser.ts
+++ b/src/argsParser.ts
@@ -37,6 +37,9 @@ function processOptions(
           });
         }
         break;
+      case '--includeDeclarationFiles':
+        newOptions.includeDeclarationFiles = true;
+        break;
       case '--showLineNumber':
         newOptions.showLineNumber = true;
         break;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -115,7 +115,8 @@ const mapFile = (
   const imports: Imports = {};
   let exports: string[] = [];
   const exportLocations: LocationInFile[] = [];
-  const name = relative(rootDir, path).replace(/([\\/]index)?\.[^.]*$/, '');
+  const name = extractFilename(rootDir, path);
+
   const baseDir = baseUrl && resolve(rootDir, baseUrl);
 
   const tsconfigPathsMatcher =
@@ -238,6 +239,19 @@ const mapFile = (
     exports,
     exportLocations,
   };
+};
+
+const extractFilename = (rootDir: string, path: string): string => {
+  let name = relative(rootDir, path).replace(/([\\/]index)?\.[^.]*$/, '');
+
+  // Imports always have the '.d' part dropped from the filename,
+  // so for the export counting to work with d.ts files, we need to also drop '.d' part.
+  // Assumption: the same folder will not contain two files like: a.ts, a.d.ts.
+  if (!!name.match(/\.d$/)) {
+    name = name.substr(0, name.length - 2);
+  }
+
+  return name;
 };
 
 const parseFile = (

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -105,6 +105,19 @@ const isRelativeToBaseDir = (baseDir: string, from: string): boolean =>
 const hasModifier = (node: ts.Node, mod: ts.SyntaxKind): boolean | undefined =>
   node.modifiers && node.modifiers.filter(m => m.kind === mod).length > 0;
 
+const extractFilename = (rootDir: string, path: string): string => {
+  let name = relative(rootDir, path).replace(/([\\/]index)?\.[^.]*$/, '');
+
+  // Imports always have the '.d' part dropped from the filename,
+  // so for the export counting to work with d.ts files, we need to also drop '.d' part.
+  // Assumption: the same folder will not contain two files like: a.ts, a.d.ts.
+  if (!!name.match(/\.d$/)) {
+    name = name.substr(0, name.length - 2);
+  }
+
+  return name;
+};
+
 const mapFile = (
   rootDir: string,
   path: string,
@@ -239,19 +252,6 @@ const mapFile = (
     exports,
     exportLocations,
   };
-};
-
-const extractFilename = (rootDir: string, path: string): string => {
-  let name = relative(rootDir, path).replace(/([\\/]index)?\.[^.]*$/, '');
-
-  // Imports always have the '.d' part dropped from the filename,
-  // so for the export counting to work with d.ts files, we need to also drop '.d' part.
-  // Assumption: the same folder will not contain two files like: a.ts, a.d.ts.
-  if (!!name.match(/\.d$/)) {
-    name = name.substr(0, name.length - 2);
-  }
-
-  return name;
 };
 
 const parseFile = (

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,6 +7,7 @@ import {
   LocationInFile,
   TsConfig,
   TsConfigPaths,
+  ExtraCommandLineOptions,
 } from './types';
 import { dirname, join, relative, resolve, sep } from 'path';
 import { existsSync, readFileSync } from 'fs';
@@ -261,14 +262,22 @@ const parseFile = (
 const parsePaths = (
   rootDir: string,
   { baseUrl, files: filePaths, paths }: TsConfig,
+  extraOptions?: ExtraCommandLineOptions,
 ): File[] => {
+  const includeDeclarationFiles =
+    extraOptions && extraOptions.includeDeclarationFiles;
+
   const files = filePaths
-    .filter(p => p.indexOf('.d.') == -1)
+    .filter(p => includeDeclarationFiles || p.indexOf('.d.') === -1)
     .map(path => parseFile(rootDir, resolve(rootDir, path), baseUrl, paths));
 
   return files;
 };
 
-export default (rootDir: string, TsConfig: TsConfig): File[] => {
-  return parsePaths(rootDir, TsConfig);
+export default (
+  rootDir: string,
+  TsConfig: TsConfig,
+  extraOptions?: ExtraCommandLineOptions,
+): File[] => {
+  return parsePaths(rootDir, TsConfig, extraOptions);
 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -265,7 +265,7 @@ const parsePaths = (
   extraOptions?: ExtraCommandLineOptions,
 ): File[] => {
   const includeDeclarationFiles =
-    extraOptions && extraOptions.includeDeclarationFiles;
+    extraOptions && !extraOptions.excludeDeclarationFiles;
 
   const files = filePaths
     .filter(p => includeDeclarationFiles || p.indexOf('.d.') === -1)

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface TsConfig {
 
 export interface ExtraCommandLineOptions {
   exitWithCount?: boolean;
+  includeDeclarationFiles?: boolean;
   pathsToIgnore?: string[];
   showLineNumber?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface TsConfig {
 
 export interface ExtraCommandLineOptions {
   exitWithCount?: boolean;
-  includeDeclarationFiles?: boolean;
+  excludeDeclarationFiles?: boolean;
   pathsToIgnore?: string[];
   showLineNumber?: boolean;
 }

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,5 +1,5 @@
 export const USAGE = `
-    usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--exitWithCount][--ignorePaths=path1;path2][--showLineNumber]
+    usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--exitWithCount][--ignorePaths=path1;path2][--includeDeclarationFiles][--showLineNumber]
 
     Note: if no file is specified after tsconfig, the files will be read from the
     tsconfig's "files" key which must be present.

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,5 +1,4 @@
-export function showUsage(): void {
-  console.error(`
+export const USAGE = `
     usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--exitWithCount][--ignorePaths=path1;path2][--excludeDeclarationFiles][--showLineNumber]
   
     Note: if no file is specified after tsconfig, the files will be read from the

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,6 +1,7 @@
-export const USAGE = `
-    usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--exitWithCount][--ignorePaths=path1;path2][--includeDeclarationFiles][--showLineNumber]
-
+export function showUsage(): void {
+  console.error(`
+    usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--exitWithCount][--ignorePaths=path1;path2][--excludeDeclarationFiles][--showLineNumber]
+  
     Note: if no file is specified after tsconfig, the files will be read from the
     tsconfig's "files" key which must be present.
 


### PR DESCRIPTION
By default, include definition (`.d.ts`) files when searching for unused exports.

Add option `--excludeDeclarationFiles` to disable that behavior.

Fixes issues:
- #59 - add option --excludeDeclarationFiles
- #29 - add tests to cover this issue which seems to be already fixed - error with "Cannot find .d.ts file in subdirectory".
