### PR TITLE
Limit max exit code when --exitWithCount option is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - (Internal) add code coverage via nyc
 - (Internal) code coverage and linting are included in `npm test`
 - (Internal) add more unit tests, increasing the code coverage
+- Limit max exit code when --exitWithCount option is used (max is 127, a signed byte)
 
 ## [3.0.3] - 30 October 2019
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,7 +68,8 @@ export const runCli = (
     }
 
     if (options && options.exitWithCount) {
-      return exitWith(files.length);
+      // Max allowed exit code is 127 (single signed byte)
+      return exitWith(Math.min(127, files.length));
     }
 
     return exitWith(


### PR DESCRIPTION
Limit the max exit code when --exitWithCount option is used.

Fixes #79 