### PR TITLE
Update dependencies to TypeScript 3.7 and simplify some code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased] - ReleaseDate
+
+### Changed
+- (Internal) Update dependency TypeScript to 3.7.3
+- (Internal) Simplify some logic, using the new optional chaining operator (?.)
+- (Internal) Increase code coverage and simplify code (baseUrl defaults to '.')
+
 ## [5.1.0] - 26 Nov 2019
 
 ### Added

--- a/features/base-url-undefined.feature
+++ b/features/base-url-undefined.feature
@@ -1,0 +1,54 @@
+Feature: baseUrl undefined
+
+Background:
+  Given file "tsconfig.json" is
+    """
+    {
+    // This is a comment
+    // note: baseUrl is NOT defined:
+    "compilerOptions": {},
+    "include": ["**/*.ts", "**/*.tsx"]
+    }
+    """
+
+Scenario: Import named with base url
+  Given file "a.ts" is export const a = 1;
+  And file "b.ts" is import { a } from 'a';
+  When analyzing "tsconfig.json"
+  Then the result is {}
+
+Scenario: Import named with base url TSX
+  Given file "a.tsx" is export const a = 1;
+  And file "b.ts" is import { a } from 'a';
+  When analyzing "tsconfig.json"
+  Then the result is {}
+
+Scenario: Import default with base url
+  Given file "a.ts" is export default 1;
+  And file "b.ts" is import a from 'a';
+  When analyzing "tsconfig.json"
+  Then the result is {}
+
+Scenario: Import default with base url TSX
+  Given file "a.tsx" is export default 1;
+  And file "b.ts" is import a from 'a';
+  When analyzing "tsconfig.json"
+  Then the result is {}
+
+Scenario: Index TS
+  Given file "dir/index.ts" is export default 1;
+  And file "b.ts" is import a from 'dir';
+  When analyzing "tsconfig.json"
+  Then the result is {}
+
+Scenario: Index JS
+  Given file "dir/index.js" is export default 1;
+  And file "b.ts" is import a from 'dir';
+  When analyzing "tsconfig.json"
+  Then the result is {}
+
+Scenario: Index TSX
+  Given file "dir/index.tsx" is export default 1;
+  And file "b.ts" is import a from 'dir';
+  When analyzing "tsconfig.json"
+  Then the result is {}

--- a/features/misc.feature
+++ b/features/misc.feature
@@ -18,6 +18,11 @@ Scenario: Import non-existent symbol (not valid TS!)
   When analyzing "tsconfig.json"
   Then the result is { "a.ts": ["a"] }
 
+Scenario: Import non-existent file (not valid TS - but tests robustness)
+  Given file "b.ts" is import { b } from './non-existent';
+  When analyzing "tsconfig.json"
+  Then the result is { }
+
 Scenario: Disable with comments
   Given file "a.ts" is
     """

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,18 +161,18 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/node": {
-      "version": "10.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
-      "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA==",
+      "version": "10.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.6.tgz",
+      "integrity": "sha512-0a2X6cgN3RdPBL2MIlR6Lt0KlM7fOFsutuXcdglcOq6WvLnYXgPQSh0Mx6tO1KCAE8MxbHSOSTWDoUxRq+l3DA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.8.0.tgz",
-      "integrity": "sha512-ohqul5s6XEB0AzPWZCuJF5Fd6qC0b4+l5BGEnrlpmvXxvyymb8yw8Bs4YMF8usNAeuCJK87eFIHy8g8GFvOtGA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.10.0.tgz",
+      "integrity": "sha512-rT51fNLW0u3fnDGnAHVC5nu+Das+y2CpW10yqvf6/j5xbuUV3FxA3mBaIbM24CXODXjbgUznNb4Kg9XZOUxKAw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.8.0",
+        "@typescript-eslint/experimental-utils": "2.10.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -180,32 +180,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.8.0.tgz",
-      "integrity": "sha512-jZ05E4SxCbbXseQGXOKf3ESKcsGxT8Ucpkp1jiVp55MGhOvZB2twmWKf894PAuVQTCgbPbJz9ZbRDqtUWzP8xA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
+      "integrity": "sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.8.0",
+        "@typescript-eslint/typescript-estree": "2.10.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.8.0.tgz",
-      "integrity": "sha512-NseXWzhkucq+JM2HgqAAoKEzGQMb5LuTRjFPLQzGIdLthXMNUfuiskbl7QSykvWW6mvzCtYbw1fYWGa2EIaekw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.10.0.tgz",
+      "integrity": "sha512-wQNiBokcP5ZsTuB+i4BlmVWq6o+oAhd8en2eSm/EE9m7BgZUIfEeYFd6z3S+T7bgNuloeiHA1/cevvbBDLr98g==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.8.0",
-        "@typescript-eslint/typescript-estree": "2.8.0",
+        "@typescript-eslint/experimental-utils": "2.10.0",
+        "@typescript-eslint/typescript-estree": "2.10.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.8.0.tgz",
-      "integrity": "sha512-ksvjBDTdbAQ04cR5JyFSDX113k66FxH1tAXmi+dj6hufsl/G0eMc/f1GgLjEVPkYClDbRKv+rnBFuE5EusomUw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
+      "integrity": "sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -304,9 +304,9 @@
       "dev": true
     },
     "arg": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
+      "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
       "dev": true
     },
     "argparse": {
@@ -375,9 +375,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
       "dev": true
     },
     "babel-runtime": {
@@ -412,9 +412,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "brace-expansion": {
@@ -426,12 +426,6 @@
         "balanced-match": "^0.4.1",
         "concat-map": "0.0.1"
       }
-    },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -576,16 +570,6 @@
         }
       }
     },
-    "cobertura-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/cobertura-parse/-/cobertura-parse-1.0.5.tgz",
-      "integrity": "sha512-uYJfkGhzw1wibe/8jqqHmSaPNWFguzq/IlSj83u3cSnZho/lUnfj0mLTmZGmB3AiKCOTYr22TYwpR1sXy2JEkg==",
-      "dev": true,
-      "requires": {
-        "mocha": "5.0.5",
-        "xml2js": "0.4.19"
-      }
-    },
     "codecov": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.6.1.tgz",
@@ -669,12 +653,11 @@
       "dev": true
     },
     "coveralls": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.8.tgz",
-      "integrity": "sha512-lkQlg29RhV9zwB0gDaEAWoap8xPgFxtPsVIpTNiDDtWNrvtP1/RmGJRRAV/Loz2gihmppObkSL0wnptEGUXaOQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
+      "integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
       "dev": true,
       "requires": {
-        "cobertura-parse": "^1.0.5",
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
@@ -952,9 +935,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.0.tgz",
-      "integrity": "sha512-dQpj+PaHKHfXHQ2Imcw5d853PTvkUGbHk/MR68KQUl98EgKDCdh4vLRH1ZxhqeQjQFJeg8fgN0UwmNhN3l8dDQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.2.tgz",
+      "integrity": "sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1130,9 +1113,9 @@
       "dev": true
     },
     "ext": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz",
-      "integrity": "sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
       "dev": true,
       "requires": {
         "type": "^2.0.0"
@@ -1361,12 +1344,6 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
-    "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
-      "dev": true
-    },
     "handlebars": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
@@ -1417,12 +1394,6 @@
       "requires": {
         "is-stream": "^1.0.1"
       }
-    },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.5",
@@ -1986,76 +1957,6 @@
         }
       }
     },
-    "mocha": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
-      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.1",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.3",
-        "he": "1.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        }
-      }
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2380,9 +2281,9 @@
       "dev": true
     },
     "pickled-cucumber": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/pickled-cucumber/-/pickled-cucumber-2.0.10.tgz",
-      "integrity": "sha512-ot03Ppc3OQl1rlXWx/J9zbVUJZOb5jHkA6dBSUzaYVTY5izMX9SAIYKE7xNe78qkx+UgqYAeQ5BuRGMeO+izPw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/pickled-cucumber/-/pickled-cucumber-2.0.11.tgz",
+      "integrity": "sha512-ZFUnqMH7zDND6GpxKORn0s90u9kzQdNtnLTQ2AljrHOwvdMEiXI5V6K0wwxN+p7HQr3seM5nm2ySbHQQzwV/0Q==",
       "dev": true,
       "requires": {
         "cucumber": "^4.2.1",
@@ -2463,9 +2364,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
+      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==",
       "dev": true
     },
     "punycode": {
@@ -2569,9 +2470,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
-      "integrity": "sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
+      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -2646,12 +2547,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "seed-random": {
@@ -3072,9 +2967,9 @@
       }
     },
     "ts-node": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.2.tgz",
-      "integrity": "sha512-W1DK/a6BGoV/D4x/SXXm6TSQx6q3blECUzd5TN+j56YEMX3yPVMpHsICLedUw3DvGF3aTQ8hfdR9AKMaHjIi+A==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+      "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -3168,9 +3063,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw=="
     },
     "uglify-js": {
       "version": "3.6.9",
@@ -3340,22 +3235,6 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
       }
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,22 +38,22 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
-    "@types/node": "^10.17.5",
-    "@typescript-eslint/eslint-plugin": "^2.8.0",
-    "@typescript-eslint/parser": "^2.8.0",
+    "@types/node": "^10.17.6",
+    "@typescript-eslint/eslint-plugin": "^2.10.0",
+    "@typescript-eslint/parser": "^2.10.0",
     "codecov": "^3.6.1",
-    "coveralls": "^3.0.8",
-    "eslint": "^6.7.0",
+    "coveralls": "^3.0.9",
+    "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-prettier": "^3.1.1",
     "nyc": "^14.1.1",
-    "pickled-cucumber": "^2.0.10",
+    "pickled-cucumber": "^2.0.11",
     "prettier": "^1.19.1",
-    "ts-node": "^8.5.2"
+    "ts-node": "^8.5.4"
   },
   "dependencies": {
     "chalk": "^3.0.0",
     "tsconfig-paths": "^3.9.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.3"
   }
 }

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -54,7 +54,7 @@ const processImports = (imports: Imports, exportMap: ExportMap): void => {
       const indexCandidates = ['index', 'index.ts', 'index.tsx'];
       for (let c = 0; c < indexCandidates.length; c++) {
         const indexKey = indexCandidates[c];
-        ex = exportMap[indexKey] && exportMap[indexKey].exports;
+        ex = exportMap[indexKey]?.exports || undefined;
         if (ex) break;
       }
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,7 +27,7 @@ const parseTsConfig = (tsconfigPath: string): TsConfig => {
     if (result.errors.length) throw result.errors;
 
     return {
-      baseUrl: result.raw?.compilerOptions?.baseUrl,
+      baseUrl: result.raw?.compilerOptions?.baseUrl || '.',
       paths: result.raw?.compilerOptions?.paths,
       files: result.fileNames,
     };

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,14 +27,8 @@ const parseTsConfig = (tsconfigPath: string): TsConfig => {
     if (result.errors.length) throw result.errors;
 
     return {
-      baseUrl:
-        result.raw &&
-        result.raw.compilerOptions &&
-        result.raw.compilerOptions.baseUrl,
-      paths:
-        result.raw &&
-        result.raw.compilerOptions &&
-        result.raw.compilerOptions.paths,
+      baseUrl: result.raw?.compilerOptions?.baseUrl,
+      paths: result.raw?.compilerOptions?.paths,
       files: result.fileNames,
     };
   } catch (e) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ export const runCli = (
     };
 
     const options = extractOptionsFromFiles(tsFiles).options;
-    if (options && options.showLineNumber) {
+    if (options?.showLineNumber) {
       files.forEach(path => {
         analysis[path].forEach(unusedExport => {
           showMessage(
@@ -67,7 +67,7 @@ export const runCli = (
       );
     }
 
-    if (options && options.exitWithCount) {
+    if (options?.exitWithCount) {
       // Max allowed exit code is 127 (single signed byte)
       return exitWith(Math.min(127, files.length));
     }

--- a/src/parser/common.ts
+++ b/src/parser/common.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 
-export const star = ['*'];
+export const STAR = ['*'];
 
 export interface FromWhat {
   from: string;

--- a/src/parser/export.ts
+++ b/src/parser/export.ts
@@ -54,10 +54,9 @@ export const extractExport = (path: string, node: ts.Node): string => {
       return name ? name.text : 'default';
     default: {
       console.warn(`WARN: ${path}: unknown export node (kind:${node.kind})`);
-      break;
+      return '';
     }
   }
-  return '';
 };
 
 export const addExportCore = (

--- a/src/parser/export.ts
+++ b/src/parser/export.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 
 import { LocationInFile } from '../types';
-import { FromWhat, star, getFrom } from './common';
+import { FromWhat, STAR, getFrom } from './common';
 
 // Parse Exports
 
@@ -26,12 +26,12 @@ export const extractExportFromImport = (
   const whatExported = exportClause
     ? // The alias 'name' or the original type is exported
       extractAliasFirstFromElements(exportClause.elements)
-    : star;
+    : STAR;
 
   const whatImported = exportClause
     ? // The original type 'propertyName' is imported
       exportClause.elements.map(e => (e.propertyName || e.name).text)
-    : star;
+    : STAR;
 
   return {
     exported: {

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -59,9 +59,9 @@ export const addImportCore = (
   rootDir: string,
   path: string,
   imports: Imports,
+  baseDir: string,
+  baseUrl: string,
   tsconfigPathsMatcher?: tsconfigPaths.MatchPath,
-  baseDir?: string,
-  baseUrl?: string,
 ): string | undefined => {
   const { from, what } = fw;
 
@@ -69,11 +69,11 @@ export const addImportCore = (
     if (from[0] == '.') {
       // An undefined return indicates the import is from 'index.ts' or similar == '.'
       return relativeTo(rootDir, path, from) || '.';
-    } else if (baseDir && baseUrl) {
+    } else {
       let matchedPath;
 
       return isRelativeToBaseDir(baseDir, from)
-        ? baseUrl && join(baseUrl, from)
+        ? join(baseUrl, from)
         : tsconfigPathsMatcher &&
           (matchedPath = tsconfigPathsMatcher(
             from,
@@ -84,8 +84,6 @@ export const addImportCore = (
         ? matchedPath.replace(`${baseDir}${sep}`, '')
         : undefined;
     }
-
-    return undefined;
   };
 
   const key = getKey(from);

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import * as tsconfigPaths from 'tsconfig-paths';
 import * as ts from 'typescript';
 
-import { getFrom, FromWhat, star } from './common';
+import { getFrom, FromWhat, STAR } from './common';
 import { Imports } from '../types';
 
 // Parse Imports
@@ -27,19 +27,26 @@ export const extractImport = (decl: ts.ImportDeclaration): FromWhat => {
   if (!importClause)
     return {
       from,
-      what: star,
+      what: STAR,
     };
 
   const { namedBindings } = importClause;
   const importDefault = !!importClause.name ? ['default'] : [];
-  const importStar =
-    namedBindings && !!(namedBindings as ts.NamespaceImport).name ? star : [];
-  const importNames =
-    namedBindings && !importStar.length
-      ? (namedBindings as ts.NamedImports).elements.map(
-          e => (e.propertyName || e.name).text,
-        )
-      : [];
+
+  if (!namedBindings) {
+    return {
+      from,
+      what: importDefault,
+    };
+  }
+
+  const isStar = !!(namedBindings as ts.NamespaceImport).name;
+  const importStar = isStar ? STAR : [];
+  const importNames = isStar
+    ? []
+    : (namedBindings as ts.NamedImports).elements.map(
+        e => (e.propertyName || e.name).text,
+      );
 
   return {
     from,

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -41,16 +41,16 @@ export const extractImport = (decl: ts.ImportDeclaration): FromWhat => {
   }
 
   const isStar = !!(namedBindings as ts.NamespaceImport).name;
-  const importStar = isStar ? STAR : [];
+
   const importNames = isStar
-    ? []
+    ? STAR
     : (namedBindings as ts.NamedImports).elements.map(
         e => (e.propertyName || e.name).text,
       );
 
   return {
     from,
-    what: importDefault.concat(importStar, importNames),
+    what: importDefault.concat(importNames),
   };
 };
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -163,8 +163,7 @@ const parsePaths = (
   { baseUrl, files: filePaths, paths }: TsConfig,
   extraOptions?: ExtraCommandLineOptions,
 ): File[] => {
-  const includeDeclarationFiles =
-    extraOptions && !extraOptions.excludeDeclarationFiles;
+  const includeDeclarationFiles = !extraOptions?.excludeDeclarationFiles;
 
   const files = filePaths
     .filter(p => includeDeclarationFiles || p.indexOf('.d.') === -1)

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -42,7 +42,7 @@ const mapFile = (
   rootDir: string,
   path: string,
   file: ts.SourceFile,
-  baseUrl?: string,
+  baseUrl: string,
   paths?: TsConfigPaths,
 ): File => {
   const imports: Imports = {};
@@ -50,10 +50,9 @@ const mapFile = (
   const exportLocations: LocationInFile[] = [];
   const name = extractFilename(rootDir, path);
 
-  const baseDir = baseUrl && resolve(rootDir, baseUrl);
+  const baseDir = resolve(rootDir, baseUrl);
   const tsconfigPathsMatcher =
-    (!!baseDir && !!paths && tsconfigPaths.createMatchPath(baseDir, paths)) ||
-    undefined;
+    (!!paths && tsconfigPaths.createMatchPath(baseDir, paths)) || undefined;
 
   const addImport = (fw: FromWhat): string | undefined => {
     return addImportCore(
@@ -61,9 +60,9 @@ const mapFile = (
       rootDir,
       path,
       imports,
-      tsconfigPathsMatcher,
       baseDir,
       baseUrl,
+      tsconfigPathsMatcher,
     );
   };
 
@@ -142,7 +141,7 @@ const mapFile = (
 const parseFile = (
   rootDir: string,
   path: string,
-  baseUrl?: string,
+  baseUrl: string,
   paths?: TsConfigPaths,
 ): File =>
   mapFile(

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -11,7 +11,7 @@ import {
 } from '../types';
 import { relative, resolve } from 'path';
 import { readFileSync } from 'fs';
-import { FromWhat, star } from './common';
+import { FromWhat, STAR } from './common';
 import { addDynamicImports, mayContainDynamicImports } from './dynamic';
 import { extractImport, addImportCore } from './import';
 import {
@@ -102,7 +102,7 @@ const mapFile = (
         const key = addImport(imported);
         if (key) {
           const { what } = exported;
-          if (what == star) {
+          if (what == STAR) {
             addExport(`*:${key}`, node);
           } else {
             exports = exports.concat(what);

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface TsConfigPaths {
 }
 
 export interface TsConfig {
-  baseUrl?: string;
+  baseUrl: string;
   paths?: TsConfigPaths;
   files: string[];
 }


### PR DESCRIPTION
- updates TypeScript to 3.7
- simplifies some code, using the new optional chaining operator `?.`
- simplifies code by defaulting baseUrl to be '.' (with tests added)