### PR TITLE
Up VS Code settings for saving eslint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,8 @@
   "prettier.useTabs": false,
   "files.exclude": {
     "lib": true
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
   }
 }


### PR DESCRIPTION
Up VS Code settings for saving eslint

else - will be prompted each time the project is opened.
