### PR TITLE
docs: Update contrib about single commit and volunteering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing
 
-Contributions to `ts-unused-exports` are always welcome - for inspiration, see our [open issues](https://github.com/pzavolinsky/ts-unused-exports/issues) or our [roadmap](https://github.com/pzavolinsky/ts-unused-exports/wiki).
+`ts-unused-exports` is maintained by volunteers, working in their free time. If you'd like to help out, contributions to `ts-unused-exports` are always welcome.
+
+For inspiration, see our [open issues](https://github.com/pzavolinsky/ts-unused-exports/issues) or our [roadmap](https://github.com/pzavolinsky/ts-unused-exports/wiki).
 
 Required tools:
 
@@ -39,6 +41,7 @@ Some things that will increase the chance that your pull request is accepted:
 - Try not to introduce new dependencies
 - Try to follow the style of the existing code
 - Write a [good commit message][commit].
+- Try to squash the branch down to 1 commit.
 
 [commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ To see what has changed in each version, please see our [CHANGELOG.md](https://g
 
 # Contributing
 
-Please see [CONTRIBUTING.md](https://github.com/pzavolinsky/ts-unused-exports/blob/master/CONTRIBUTING.md).
+`ts-unused-exports` is maintained by volunteers, working in their free time. If you'd like to help out, please see [CONTRIBUTING.md](https://github.com/pzavolinsky/ts-unused-exports/blob/master/CONTRIBUTING.md).
 
 `ts-unused-exports` was created by Patricio Zavolinsky. Improvements were contributed by the [open source
 community](https://github.com/pzavolinsky/ts-unused-exports/graphs/contributors).


### PR DESCRIPTION
docs: 

- Update contrib about single commit 
- also mention that the project is maintained by volunteers

@pzavolinsky  I thought of mentioning the 'volunteers' part as this is what [fuse-box](https://github.com/fuse-box/fuse-box) do.  Maybe it will help to get more contributors ?

btw this project is just as popular as fuse-box !