### PR TITLE
feature: Add options to ignore imports from tests or other files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased] - ReleaseDate
+
+### Added
+
+- Add options to ignore imports from certain files: --ignoreFiles, --ignoreProductionFiles, --ignoreTestFiles
+
+### Changed
+
+- BREAKING CHANGE: renamed the option --ignorePaths to be --excludePathsFromReport
+
 ## [5.5.0] - 20 Jan 2020
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ or, as a library:
 import analyzeTsConfig from 'ts-unused-exports';
 const result = analyzeTsConfig('path/to/tsconfig.json');
 // or const result = analyzeTsConfig('path/to/tsconfig.json', ['file1.ts']);
-// or const result = analyzeTsConfig('path/to/tsconfig.json', ['file1.ts', '--ignorePaths=math']);
+// or const result = analyzeTsConfig('path/to/tsconfig.json', ['file1.ts', '--excludePathsFromReport=math']);
 
 // result : { [index:string] : ExportNameAndLocation[] }
 // where the keys are file paths and the values are a structure descibing unused symbols:
@@ -53,14 +53,17 @@ const result = analyzeTsConfig('path/to/tsconfig.json');
 
 Options:
 
-| Option name               | Description                                                                                                  | Example                     |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------- |
-| `allowUnusedTypes`        | Allow unused `type` or `interface`.                                                                          | `--allowUnusedTypes`        |
-| `excludeDeclarationFiles` | Exclude `.d.ts` files when looking for unused exports.                                                       | `--excludeDeclarationFiles` |
-| `exitWithCount`           | Set the process exit code to be the count of files that have unused exports.                                 | `--exitWithCount`           |
-| `ignorePaths`             | Exclude files that match the given path segments.                                                            | `--ignorePaths=math;utils`  |
-| `--searchNamespaces`      | Enable searching for unused exports within namespaces. Note: this can affect performance on large codebases. | `--searchNamespaces`        |
-| `showLineNumber`          | Show the line number and column of the unused export.                                                        | `--showLineNumber`          |
+| Option name               | Description                                                                                                                                                                                                                                                                                                                                            | Example                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| `allowUnusedTypes`        | Allow unused `type` or `interface`.                                                                                                                                                                                                                                                                                                                    | `--allowUnusedTypes`                  |
+| `excludeDeclarationFiles` | Exclude `.d.ts` files when looking for unused exports.                                                                                                                                                                                                                                                                                                 | `--excludeDeclarationFiles`           |
+| `exitWithCount`           | Set the process exit code to be the count of files that have unused exports.                                                                                                                                                                                                                                                                           | `--exitWithCount`                     |
+| `ignoreFiles`             | Ignore files with filenames that match the given regex. Use this to exclude groups of files - for example test files and their utilities.                                                                                                                                                                                                              | `--ignoreFiles=\.(spec|test)`         |
+| `ignoreProductionFiles`   | Only scan **test** files (so ignore non-test 'production' files).                                                                                                                                                                                                                                                                                      | `--ignoreProductionFiles`             |
+| `ignoreTestFiles`         | Only scan **production** files (ignore all test files, like `spec.ts(x)` or `test.ts(x)` or `TestUtils.ts`). Use this to detect production code that is only used in tests (so is dead code). Note: this will NOT detect unused exports in test code - for that, you can run `ts-unused-exports` separately with the `--ignoreProductionFiles` option. | `--ignoreTestFiles`                   |
+| `excludePathsFromReport`  | Exclude files from the _output_ that match the given path segments.                                                                                                                                                                                                                                                                                    | `--excludePathsFromReport=math;utils` |
+| `searchNamespaces`        | Enable searching for unused exports within namespaces. Note: this can affect performance on large codebases.                                                                                                                                                                                                                                           | `--searchNamespaces`                  |
+| `showLineNumber`          | Show the line number and column of the unused export.                                                                                                                                                                                                                                                                                                  | `--showLineNumber`                    |
 
 Note that if `ts-unused-exports` is called without files, the files will be read from the tsconfig's `files` or `include` key which must be present. If called with files, then those file paths should be relative to the `tsconfig.json`, just like you would specify them in your tsconfig's `files` key.
 

--- a/example/with-paths/package.json
+++ b/example/with-paths/package.json
@@ -1,15 +1,15 @@
 {
-    "description": "Example used by integration tests (ispec)",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/pzavolinsky/ts-unused-exports.git"
-    },
-    "license": "MIT",
-    "scripts": {
-        "build": "tsc",
-        "test": "npm i && npm run build && ../../bin/ts-unused-exports ./tsconfig.json --ignorePaths=to-ignore"
-    },
-    "dependencies": {
-        "typescript": "^3.6.4"
-    }
+  "description": "Example used by integration tests (ispec)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pzavolinsky/ts-unused-exports.git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm i && npm run build && ../../bin/ts-unused-exports ./tsconfig.json --excludePathsFromReport=to-ignore"
+  },
+  "dependencies": {
+    "typescript": "^3.6.4"
+  }
 }

--- a/example/with-paths/utils/src/to-ignore.ts
+++ b/example/with-paths/utils/src/to-ignore.ts
@@ -1,2 +1,2 @@
-// Should be ignored due to --ignorePaths option
+// Should be ignored due to --excludePathsFromReport option
 export const unused_fun = () => 0;

--- a/features/exclude-paths-from-report.feature
+++ b/features/exclude-paths-from-report.feature
@@ -2,10 +2,10 @@ Feature: ignore paths
 
 Scenario: Ignore all
   Given file "exports.ts" is export const a = 1;
-  When analyzing "tsconfig.json" with files ["--ignorePaths=exports;other-1"]
+  When analyzing "tsconfig.json" with files ["--excludePathsFromReport=exports;other-1"]
   Then the result is {}
 
 Scenario: Ignore none
   Given file "exports.ts" is export const a = 1;
-  When analyzing "tsconfig.json" with files ["--ignorePaths=other-1;other-2"]
+  When analyzing "tsconfig.json" with files ["--excludePathsFromReport=other-1;other-2"]
   Then the result is { "exports.ts": ["a"] }

--- a/features/ignore-imports-from.feature
+++ b/features/ignore-imports-from.feature
@@ -1,0 +1,90 @@
+Feature: ignoreFiles option
+
+Background:
+  Given file "a.ts" is
+    """
+    export function onlyUsedInTests(a, b) { return a + b; };
+    export const a_unused = 1;
+    """
+  And file "a.test.ts" is
+    """
+    import {onlyUsedInTests} from "./a";
+    """
+
+Scenario: Not ignoring any files
+  When analyzing "tsconfig.json"
+  Then the result at a.ts is ["a_unused"]
+
+Scenario: Ignoring test files
+  When analyzing "tsconfig.json" with files ["--ignoreTestFiles"]
+  Then the result at a.ts is ["onlyUsedInTests", "a_unused"]
+
+Scenario: Ignoring test files via regex
+  When analyzing "tsconfig.json" with files ["--ignoreFiles=a\\.test"]
+  Then the result at a.ts is ["onlyUsedInTests", "a_unused"]
+
+Scenario: Ignoring other files via regex
+  When analyzing "tsconfig.json" with files ["--ignoreFiles=x\\.y"]
+  Then the result at a.ts is ["a_unused"]
+
+# Only evaluate *production* files (ignore all test files).
+#
+# This is used to find production code that is only used in tests (so is dead code).
+# note: this will NOT detect unused exports in test code.
+Scenario: Ignoring all test files, with test-utils files
+  Given file "TestUtils.ts" is
+    """
+    export function helpTest() {}";
+
+    export function unusedFromUtils() {}";
+    """
+  And file "b.test.ts" is
+    """
+    import {onlyUsedInTests} from "./a";
+    import {helpTest} from "./TestUtils";
+
+    export function unusedFromTest() {}";
+    """
+  When analyzing "tsconfig.json" with files ["--ignoreTestFiles"]
+  Then the result is { "a.ts": ["onlyUsedInTests", "a_unused"] }
+
+# Only evaluate *test* files (ignore all non-test files).
+#
+# This is used to avoid having false positives from 'test utils' code, that is not exactly a test, but is not production code.
+# note: this will NOT detect unused exports in production code.
+Scenario: Ignoring all non-test files, with test-utils files
+  Given file "TestUtils.ts" is
+    """
+    export function helpTest() {}";
+
+    export function unusedFromUtils() {}";
+    """
+  And file "b.test.ts" is
+    """
+    import {onlyUsedInTests} from "./a";
+    import {helpTest} from "./TestUtils";
+
+    export function unusedFromTest() {}";
+    """
+  # note: this complex regex is covered with the option --ignoreProductionFiles
+  When analyzing "tsconfig.json" with files ["--ignoreFiles=^(?!.*(test|Test)).*$"]
+  Then the result is { "TestUtils.ts": ["unusedFromUtils"], "b.test.ts": ["unusedFromTest"] }
+
+# Only evaluate *test* files (ignore all non-test files).
+# - using --ignoreProductionFiles
+Scenario: Ignoring all non-test files, with test-utils files
+  Given file "TestUtils.ts" is
+    """
+    export function helpTest() {}";
+
+    export function unusedFromUtils() {}";
+    """
+  And file "b.test.ts" is
+    """
+    import {onlyUsedInTests} from "./a";
+    import {helpTest} from "./TestUtils";
+
+    export function unusedFromTest() {}";
+    """
+  When analyzing "tsconfig.json" with files ["--ignoreProductionFiles"]
+  Then the result is { "TestUtils.ts": ["unusedFromUtils"], "b.test.ts": ["unusedFromTest"] }

--- a/ispec/_run-and-check-exit-code.sh
+++ b/ispec/_run-and-check-exit-code.sh
@@ -2,7 +2,7 @@
 set +e;
 
 function run {
-    node ../../bin/ts-unused-exports tsconfig.json --exitWithCount --ignorePaths=to-ignore $1
+    node ../../bin/ts-unused-exports tsconfig.json --exitWithCount --excludePathsFromReport=to-ignore $1
     ERROR_COUNT=$?
     if [ $ERROR_COUNT -ne 2 ]
     then

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,8 @@ export interface ExtraCommandLineOptions {
   allowUnusedTypes?: boolean;
   exitWithCount?: boolean;
   excludeDeclarationFiles?: boolean;
-  pathsToIgnore?: string[];
+  ignoreFilesRegex?: string[];
+  pathsToExcludeFromReport?: string[];
   searchNamespaces?: boolean;
   showLineNumber?: boolean;
 }

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,6 +1,17 @@
 export const USAGE = `
-    usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [--allowUnusedTypes][--excludeDeclarationFiles][--exitWithCount][--ignorePaths=path1;path2][--searchNamespaces][--showLineNumber]
-  
+    usage: ts-unused-exports path/to/tsconfig.json [file1.ts file2.ts] [options]
+    
+    where options are any of:
+      --allowUnusedTypes
+      --excludeDeclarationFiles
+      --excludePathsFromReport=path1;path2
+      --exitWithCount
+      --ignoreFiles=<regex>
+      --ignoreProductionFiles
+      --ignoreTestFiles
+      --searchNamespaces
+      --showLineNumber
+
     Note: if no file is specified after tsconfig, the files will be read from the
     tsconfig's "files" key which must be present.
 


### PR DESCRIPTION
feature: Add options to ignore imports from tests or other files.

Addresses part of #2 and fixes #98 

The options are:

| Option name               | Description                                                                                                  | Example                             |
| ------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
| `ignoreFiles`             | Ignore files with filenames that match the given regex. Use this to exclude groups of files - for example test files and their utilities.                                                                                                                                                                                                              | `--ignoreFiles=\.(spec|test)`         |
| `ignoreProductionFiles`   | Only scan **test** files (so ignore non-test 'production' files).                                                                                                                                                                                                                                                                                      | `--ignoreProductionFiles`             |
| `ignoreTestFiles`         | Only scan **production** files (ignore all test files, like `spec.ts(x)` or `test.ts(x)` or `TestUtils.ts`). Use this to detect production code that is only used in tests (so is dead code). Note: this will NOT detect unused exports in test code - for that, you can run `ts-unused-exports` separately with the `--ignoreProductionFiles` option.                             | `--ignoreTestFiles` |

BREAKING CHANGE:
- rename the option `ignorePaths` to `excludePathsFromReport` - (otherwise is confusing!)