### PR TITLE
Fix to support destructured exports like 'export const { a, b }'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Changed
+
+- Fix to support destructuerd exports like 'export const { a, b }'
+
 ## [6.0.0] - 24 Jan 2020
 
 ### Added

--- a/features/export-statements.feature
+++ b/features/export-statements.feature
@@ -76,3 +76,18 @@ Scenario: Include files indirectly from sub-folder, without error
     """
   When analyzing "tsconfig.json"
   Then the result is { "b.ts": ["B_unused"], "c.ts": ["C_unused"], "x/a.ts": ["A_unused"] }
+
+Scenario: Import a destructured export
+  Given file "a.ts" is
+    """
+    const complex = { a: "1", b: "2" };
+    export const { a, b } = complex;
+    export const A_unused = 1;
+    """
+  And file "b.ts" is
+    """
+    import { a, b } from "./a";
+    export const B_unused = 1;
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["B_unused"], "a.ts": ["A_unused"] }

--- a/src/parser/export.ts
+++ b/src/parser/export.ts
@@ -45,16 +45,28 @@ export const extractExportFromImport = (
   };
 };
 
-export const extractExport = (path: string, node: ts.Node): string => {
+// Can be a name like 'a' or else a destructured set like '{ a, b }'
+const parseExportNames = (exportName: string): string[] => {
+  if (exportName.startsWith('{')) {
+    const names = exportName.substring(1, exportName.length - 2);
+    return names.split(',').map(n => n.trim());
+  }
+
+  return [exportName];
+};
+
+export const extractExportNames = (path: string, node: ts.Node): string[] => {
   switch (node.kind) {
     case ts.SyntaxKind.VariableStatement:
-      return (node as ts.VariableStatement).declarationList.declarations[0].name.getText();
+      return parseExportNames(
+        (node as ts.VariableStatement).declarationList.declarations[0].name.getText(),
+      );
     case ts.SyntaxKind.FunctionDeclaration:
       const { name } = node as ts.FunctionDeclaration;
-      return name ? name.text : 'default';
+      return [name ? name.text : 'default'];
     default: {
       console.warn(`WARN: ${path}: unknown export node (kind:${node.kind})`);
-      return '';
+      return [''];
     }
   }
 };


### PR DESCRIPTION
Fix to support destructured exports like 'export const { a, b }'

Fixes #119