### PR TITLE
fix: Fixes for detecting unused  dynamic imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Changed
 
 - Fix to support destructuerd exports with renaming, like 'export const { a: a2 }'
+- Fix: Dynamic import with destructuring and renaming
+- Fix: Do not classify other lambdas as using a dynamic import
+- Fix: Include methods when searching for dynamic imports
 
 ## [6.1.0] - 4 Mar 2020
 


### PR DESCRIPTION
Fixes for detecting unused  dynamic imports:

* fix: Include methods of classes when searching for dynamic imports
* fix: Do not classify other lambdas as using a dynamic import
* fix: Dynamic import with destructuring and renaming

Fixes #124 #123