### PR TITLE
Make analyzer more robust, add export * tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+### Changed
+
+- Fix to make the exports analyzer more robust
+
 ## [6.1.1] - 22 Mar 2020
 
 ### Changed
 
-- Fix to support destructuerd exports with renaming, like 'export const { a: a2 }'
+- Fix to support destructured exports with renaming, like 'export const { a: a2 }'
 - Fix: Dynamic import with destructuring and renaming
 - Fix: Do not classify other lambdas as using a dynamic import
 - Fix: Include methods when searching for dynamic imports

--- a/features/export-statements.feature
+++ b/features/export-statements.feature
@@ -106,3 +106,27 @@ Scenario: Import a destructured export with renamings
     """
   When analyzing "tsconfig.json"
   Then the result is { "b.ts": ["B_unused"], "a.ts": ["A_unused"] }
+
+Scenario: export * from ./a/a.ts
+  Given file "a/a.ts" is
+    """
+    export const A = 1;
+    export const A_unused = 1;
+    """
+  And file "b.ts" is export * from './a/a';
+  And file "c.ts" is import { A } from './b';
+
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["A_unused"] }
+
+Scenario: export * from ./a
+  Given file "a/index.ts" is
+    """
+    export const A = 1;
+    export const A_unused = 1;
+    """
+  And file "b.ts" is export * from './a';
+  And file "c.ts" is import { A } from './b';
+
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["A_unused"] }

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -118,18 +118,21 @@ const expandExportFromStar = (files: File[], exportMap: ExportMap): void => {
       .forEach(ex => {
         delete fileExports.exports[ex];
 
-        Object.keys(exportMap[ex.slice(2)].exports)
-          .filter(e => e != 'default')
-          .forEach(key => {
-            if (!fileExports.exports[key]) {
-              const export1 = exportMap[ex.slice(2)].exports[key];
-              fileExports.exports[key] = {
-                usageCount: 0,
-                location: export1.location,
-              };
-            }
-            fileExports.exports[key].usageCount = 0;
-          });
+        const exports = exportMap[ex.slice(2)]?.exports;
+        if (exports) {
+          Object.keys(exports)
+            .filter(e => e != 'default')
+            .forEach(key => {
+              if (!fileExports.exports[key]) {
+                const export1 = exports[key];
+                fileExports.exports[key] = {
+                  usageCount: 0,
+                  location: export1.location,
+                };
+              }
+              fileExports.exports[key].usageCount = 0;
+            });
+        }
       });
   });
 };


### PR DESCRIPTION
Make analyzer more robust.

Provides path for #132 so at least there is not an exception.

Also adds some tests around `export *`