### PR TITLE
Fix dynamic parsing with whitespace and also with assigning to a promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Changed
+
+- Fix: Dynamically import with destructuring and less whitespace
+- Fix: Dynamically import to a promise (Issue #139)
+- Fix: Dynamically import with lambda inside div (Issue #140)
+- (Internal) Add dynamic import tests involving ternary operator
+
 ## [6.2.0] - 11 May 2020
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,6 @@ Back in **Visual Code**, open a file, add a breakpoint (`F9`).
 Open a `.feature` file, put the cursor over a `Scenario:` line and press `F5`.
 
 If you don't know where to put the breakpoint, you can always put it in the first line of the default export of `app.ts`.
+
+Hint: to simplify debugging, you can comment out all the other tests in the file.
+In **Visual Code**, a quick way to do this, is to select the tests you want to skip, and press `CTRL + /`.

--- a/features/include-dynamic-imports.feature
+++ b/features/include-dynamic-imports.feature
@@ -138,3 +138,77 @@ Scenario: Dynamically import with destructuring and renaming
     """
   When analyzing "tsconfig.json"
   Then the result is { "b.ts": ["B_unused"], "a.ts": ["A_unused"] }
+
+Scenario: Dynamically import with destructuring and less whitespace
+  Given file "a.ts" is
+    """
+    export const A = 1;
+    export const A_unused = 2;
+    """
+  And file "b.ts" is
+    """
+    import('./a').then(({A}) => {console.log(A);});
+    export const B_unused = 1;
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "b.ts": ["B_unused"], "a.ts": ["A_unused"] }
+
+Scenario: Dynamically import to a promise
+  Given file "a.ts" is
+    """
+    export class A {}
+    export const A_unused = 1;
+    """
+  And file "b.ts" is
+    """
+    const promise1 = import('./a').then(({ A }) => new A());
+    export const B_unused = 1;
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "a.ts": ["A_unused"],  "b.ts": ["B_unused"] }
+
+Scenario: Dynamically import inside a ternary operator - classes
+  Given file "a.ts" is
+    """
+    export class A {}
+    export const A_unused = 1;
+    """
+  And file "b.ts" is
+    """
+    export class B {}
+    export const B_unused = 2;
+    """
+  And file "c.ts" is
+    """
+    const foo = true;
+    const promise1 = foo
+    ? import('./a').then(({ A }) => new A())
+    : import('./b').then(({ B }) => new B());
+
+    export const C_unused = 1;
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "a.ts": ["A_unused"],  "b.ts": ["B_unused"], "c.ts": ["C_unused"] }
+
+Scenario: Dynamically import inside a ternary operator - functions
+  Given file "a.ts" is
+    """
+    export const DoA = () => 0;
+    export const A_unused = 1;
+    """
+  And file "b.ts" is
+    """
+    export const DoB = () => 0;
+    export const B_unused = 2;
+    """
+  And file "c.ts" is
+    """
+    const foo = true;
+    const promise2 = foo
+    ? import('./a').then(({ DoA }) => DoA())
+    : import('./b').then(({ DoB }) => DoB());
+
+    export const C_unused = 1;
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "a.ts": ["A_unused"],  "b.ts": ["B_unused"], "c.ts": ["C_unused"] }

--- a/src/parser/dynamic.ts
+++ b/src/parser/dynamic.ts
@@ -107,49 +107,10 @@ const addImportViaLambda = (
   return whatFromLambda.length !== 0;
 };
 
-const isLambaExpressionWith5Children = (node: ts.Node): boolean => {
-  return (
-    node.kind === ts.SyntaxKind.ArrowFunction && node.getChildCount() === 5
-  );
-};
-
 type ExpressionParser = (
   expr: ts.Expression,
   addImport: (fw: FromWhat) => void,
 ) => boolean;
-
-const tryParseLambdaExpression = (
-  expr: ts.Expression,
-  addImport: (fw: FromWhat) => void,
-  expressionParser: ExpressionParser,
-): boolean => {
-  const rhs = expr.getChildAt(4);
-
-  const syntaxListWithFrom = findFirstChildOfKind(
-    rhs,
-    ts.SyntaxKind.SyntaxList,
-  );
-  if (!syntaxListWithFrom) {
-    return false;
-  }
-
-  let subExpr: ts.Expression | null = null;
-
-  if (ts.isBinaryExpression(rhs) || ts.isCallExpression(rhs)) {
-    subExpr = (rhs as object) as ts.Expression;
-  } else {
-    subExpr = findFirstChildOfKind(
-      syntaxListWithFrom,
-      ts.SyntaxKind.ExpressionStatement,
-    ) as ts.Expression;
-  }
-
-  if (!subExpr) {
-    return false;
-  }
-
-  return expressionParser(subExpr, addImport);
-};
 
 const tryParseImportExpression: ExpressionParser = (
   expr: ts.Expression,
@@ -180,11 +141,6 @@ const tryParseExpression: ExpressionParser = (
   expr: ts.Expression,
   addImport: (fw: FromWhat) => void,
 ): boolean => {
-  if (isLambaExpressionWith5Children(expr)) {
-    if (tryParseLambdaExpression(expr, addImport, tryParseExpression))
-      return true;
-  }
-
   if (expr.getText().startsWith('import')) {
     return tryParseImportExpression(expr, addImport);
   }


### PR DESCRIPTION
Fix dynamic parsing with whitespace and also with assigning to a promise

Fixes #139 and Fixes #140

- Fix: Dynamically import with destructuring and less whitespace
- Fix: Dynamically import to a promise (Issue #139)
- Fix: Dynamically import with lambda inside div (Issue #140)
- (Internal) Add dynamic import tests involving ternary operator
