### PR TITLE
chore: Add node 14 to the travis list of nodes to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - 10
   - 12
-  # TODO - 14 when it is released
+  - 14
+  # TODO - 16 when it is released
 notifications:
     email: false
 script:


### PR DESCRIPTION
Add node 14 to the travis list of nodes to test

This is to keep our test setup up to date, and find out early, if there are any issues with Node 14.
