### PR TITLE
check for .d.ts files for absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Changed
+
+- Fix: false positives if importing from a d.ts file, and tsconfig is set to use either absolute paths (baseUrl) or aliases (paths).
+
 ## [6.2.1] - 1 Jun 2020
 
 ### Changed

--- a/example/definition-files-absolute-paths/src/components/UnusedComponent.ts
+++ b/example/definition-files-absolute-paths/src/components/UnusedComponent.ts
@@ -1,0 +1,1 @@
+export class UnusedComponent {}

--- a/example/definition-files-absolute-paths/src/main.ts
+++ b/example/definition-files-absolute-paths/src/main.ts
@@ -1,0 +1,3 @@
+import { Model } from 'models';
+
+export class UnusedClassFromMain implements Model {}

--- a/example/definition-files-absolute-paths/src/models.d.ts
+++ b/example/definition-files-absolute-paths/src/models.d.ts
@@ -1,0 +1,2 @@
+export interface Model {
+}

--- a/example/definition-files-absolute-paths/tsconfig.json
+++ b/example/definition-files-absolute-paths/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "baseDir": ".",
+  "compilerOptions": {
+    "baseUrl": "src"
+  },
+  "include": ["./src"]
+}

--- a/ispec/run.sh
+++ b/ispec/run.sh
@@ -18,6 +18,10 @@ pushd ../example/simple
 run_itest
 popd
 
+pushd ../example/definition-files-absolute-paths
+run_itest
+popd
+
 pushd ../example/tsx
 install_and_run_itest
 popd

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -18,6 +18,7 @@ const relativeTo = (rootDir: string, file: string, path: string): string =>
 const isRelativeToBaseDir = (baseDir: string, from: string): boolean =>
   existsSync(resolve(baseDir, `${from}.js`)) ||
   existsSync(resolve(baseDir, `${from}.ts`)) ||
+  existsSync(resolve(baseDir, `${from}.d.ts`)) ||
   existsSync(resolve(baseDir, `${from}.tsx`)) ||
   existsSync(resolve(baseDir, from, 'index.js')) ||
   existsSync(resolve(baseDir, from, 'index.ts')) ||


### PR DESCRIPTION
Uses fix created by @davidparkagoda with a CHANGELOG added.

Replaces the PR #141 

Summary:

Fixes a bug where there are false positives, if importing from a d.ts file.
This only occurs if tsconfig uses absolute paths (baseUrl) or uses aliases (paths).
