### PR TITLE
check for .d.ts files for path aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Changed
+
+- Fix: false positives if importing from a d.ts file, and tsconfig is set to use aliases (paths).
+
 ## [6.2.1] - 1 Jun 2020
 
 ### Changed

--- a/example/definition-files-with-paths/src/components/UnusedComponent.js
+++ b/example/definition-files-with-paths/src/components/UnusedComponent.js
@@ -1,0 +1,8 @@
+"use strict";
+exports.__esModule = true;
+var UnusedComponent = /** @class */ (function () {
+    function UnusedComponent() {
+    }
+    return UnusedComponent;
+}());
+exports.UnusedComponent = UnusedComponent;

--- a/example/definition-files-with-paths/src/components/UnusedComponent.ts
+++ b/example/definition-files-with-paths/src/components/UnusedComponent.ts
@@ -1,0 +1,1 @@
+export class UnusedComponent {}

--- a/example/definition-files-with-paths/src/main.ts
+++ b/example/definition-files-with-paths/src/main.ts
@@ -1,0 +1,3 @@
+import { Model } from 'some/models';
+
+export class UnusedClassFromMain implements Model {}

--- a/example/definition-files-with-paths/src/utils/some/models.d.ts
+++ b/example/definition-files-with-paths/src/utils/some/models.d.ts
@@ -1,0 +1,2 @@
+export interface Model {
+}

--- a/example/definition-files-with-paths/tsconfig.json
+++ b/example/definition-files-with-paths/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "some": ["utils/some"],
+      "some/*": ["utils/some/*"]
+    }
+  },
+  "include": ["./src"]
+}

--- a/example/definition-files-with-paths/tsconfig.json
+++ b/example/definition-files-with-paths/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
+    "baseUrl": ".",
     "paths": {
-      "some": ["utils/some"],
-      "some/*": ["utils/some/*"]
+      "some": ["src/utils/some"],
+      "some/*": ["src/utils/some/*"]
     }
-  },
-  "include": ["./src"]
+  }
 }

--- a/features/import-with-paths.feature
+++ b/features/import-with-paths.feature
@@ -4,11 +4,13 @@ Background:
     Given file "tsconfig.json" is
         """
         {
-            "baseDir": "src",
-            "paths": {
-              "components": ["src/nested/components/some"],
-              "components/*": ["src/nested/components/*"]
-            }
+            "baseDir": ".",
+            "compilerOptions": {
+              "paths": {
+                "components": ["src/nested/components/some"],
+                "components/*": ["src/nested/components/*"]
+              }
+            },
             "include": [
                 "./src"
             ]

--- a/features/import-with-paths.feature
+++ b/features/import-with-paths.feature
@@ -7,7 +7,7 @@ Background:
             "baseDir": ".",
             "compilerOptions": {
               "paths": {
-                "components": ["src/nested/components/some"],
+                "components": ["src/nested/components"],
                 "components/*": ["src/nested/components/*"]
               }
             },
@@ -18,7 +18,7 @@ Background:
         """
 
 Scenario: Import component using path aliases for declaration files
-    Given file "./src/components/MyComponent.d.ts" is
+    Given file "./src/nested/components/MyComponent.d.ts" is
         """
         export interface MyComponent1 {};
         export interface UnusedComponent {};
@@ -28,10 +28,10 @@ Scenario: Import component using path aliases for declaration files
         import {MyComponent1} from "components/MyComponent";
         """
     When analyzing "tsconfig.json"
-    Then the result is { "src/components/MyComponent.ts": ["UnusedComponent"] }
+    Then the result is { "src/components/MyComponent.d.ts": ["UnusedComponent"] }
 
 Scenario: Import component using path aliases
-    Given file "./src/components/MyComponent.ts" is
+    Given file "./src/nested/components/MyComponent.ts" is
         """
         export class MyComponent1 {};
         export class UnusedComponent {};
@@ -41,4 +41,4 @@ Scenario: Import component using path aliases
         import {MyComponent1} from "components/MyComponent";
         """
     When analyzing "tsconfig.json"
-    Then the result is { "src/components/MyComponent.ts": ["UnusedComponent"] }
+    Then the result is { "src/nested/components/MyComponent.ts": ["UnusedComponent"] }

--- a/features/import-with-paths.feature
+++ b/features/import-with-paths.feature
@@ -28,7 +28,7 @@ Scenario: Import component using path aliases for declaration files
         import {MyComponent1} from "components/MyComponent";
         """
     When analyzing "tsconfig.json"
-    Then the result is { "src/components/MyComponent.d.ts": ["UnusedComponent"] }
+    Then the result is { "src/nested/components/MyComponent.d.ts": ["UnusedComponent"] }
 
 Scenario: Import component using path aliases
     Given file "./src/nested/components/MyComponent.ts" is

--- a/features/import-with-paths.feature
+++ b/features/import-with-paths.feature
@@ -1,0 +1,42 @@
+Feature: absolute-paths without paths set in tsconfig
+
+Background:
+    Given file "tsconfig.json" is
+        """
+        {
+            "baseDir": "src",
+            "paths": {
+              "components": ["src/nested/components/some"],
+              "components/*": ["src/nested/components/*"]
+            }
+            "include": [
+                "./src"
+            ]
+        }
+        """
+
+Scenario: Import component using path aliases for declaration files
+    Given file "./src/components/MyComponent.d.ts" is
+        """
+        export interface MyComponent1 {};
+        export interface UnusedComponent {};
+        """
+    And file "src/b.ts" is
+        """
+        import {MyComponent1} from "components/MyComponent";
+        """
+    When analyzing "tsconfig.json"
+    Then the result is { "src/components/MyComponent.ts": ["UnusedComponent"] }
+
+Scenario: Import component using path aliases
+    Given file "./src/components/MyComponent.ts" is
+        """
+        export class MyComponent1 {};
+        export class UnusedComponent {};
+        """
+    And file "src/b.ts" is
+        """
+        import {MyComponent1} from "components/MyComponent";
+        """
+    When analyzing "tsconfig.json"
+    Then the result is { "src/components/MyComponent.ts": ["UnusedComponent"] }

--- a/ispec/run.sh
+++ b/ispec/run.sh
@@ -18,6 +18,10 @@ pushd ../example/simple
 run_itest
 popd
 
+pushd ../example/definition-files-with-paths
+run_itest
+popd
+
 pushd ../example/tsx
 install_and_run_itest
 popd

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -59,6 +59,12 @@ export const extractImport = (decl: ts.ImportDeclaration): FromWhat => {
   };
 };
 
+const declarationFilePatch = (matchedPath: string) => {
+  return matchedPath.endsWith('.d') && existsSync(`${matchedPath}.ts`) ?
+    matchedPath.slice(0, -2) :
+    matchedPath;
+}
+
 export const addImportCore = (
   fw: FromWhat,
   rootDir: string,
@@ -86,7 +92,7 @@ export const addImportCore = (
             undefined,
             EXTENSIONS,
           ))
-        ? matchedPath.replace(`${baseDir}${sep}`, '')
+        ? declarationFilePatch(matchedPath).replace(`${baseDir}${sep}`, '')
         : undefined;
     }
   };

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -60,10 +60,10 @@ export const extractImport = (decl: ts.ImportDeclaration): FromWhat => {
 };
 
 const declarationFilePatch = (matchedPath: string) => {
-  return matchedPath.endsWith('.d') && existsSync(`${matchedPath}.ts`) ?
-    matchedPath.slice(0, -2) :
-    matchedPath;
-}
+  return matchedPath.endsWith('.d') && existsSync(`${matchedPath}.ts`)
+    ? matchedPath.slice(0, -2)
+    : matchedPath;
+};
 
 export const addImportCore = (
   fw: FromWhat,

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -10,7 +10,7 @@ import { isUnique } from './util';
 
 // Parse Imports
 
-const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+const EXTENSIONS = ['.d.ts', '.ts', '.tsx', '.js', '.jsx'];
 
 const relativeTo = (rootDir: string, file: string, path: string): string =>
   relative(rootDir, resolve(dirname(file), path));


### PR DESCRIPTION
Summary:

Tries to fix a bug where there are false positives, if importing from a d.ts file.
This only occurs if tsconfig uses aliases (paths).

This PR would need another PR to be merged in
https://github.com/dividab/tsconfig-paths/pull/124

Right now tsconfig-paths is returning file paths with the extension stripped, `src/something/hi.ts` => `src/something/hi`. 
However this extension stripping only removes 1 level of `.` so when we matched `.d.ts` files it will incorrectly strip the extension to be like `src/something/hi.d.ts` => `src/something/hi.d`. 