### PR TITLE
Add patch for declaration files - when importing from d.ts file - aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## [6.2.2] - 25 Aug 2020
 
 ### Changed
+
+- Fix: false positives if importing from a d.ts file, and tsconfig is set to use aliases (paths).
+
+## [6.2.2] - 25 Aug 2020
+
+### Changed
 - Fix: when dynamic import has curly braces around parameter
 - Fix: false positives if importing from a d.ts file, and tsconfig is set to use either absolute paths (baseUrl) or aliases (paths).
 

--- a/example/definition-files-with-paths/src/components/UnusedComponent.ts
+++ b/example/definition-files-with-paths/src/components/UnusedComponent.ts
@@ -1,0 +1,1 @@
+export class UnusedComponent {}

--- a/example/definition-files-with-paths/src/main.ts
+++ b/example/definition-files-with-paths/src/main.ts
@@ -1,0 +1,3 @@
+import { Model } from 'some/models';
+
+export class UnusedClassFromMain implements Model {}

--- a/example/definition-files-with-paths/src/utils/some/models.d.ts
+++ b/example/definition-files-with-paths/src/utils/some/models.d.ts
@@ -1,0 +1,2 @@
+export interface Model {
+}

--- a/example/definition-files-with-paths/tsconfig.json
+++ b/example/definition-files-with-paths/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "some": ["src/utils/some"],
+      "some/*": ["src/utils/some/*"]
+    }
+  }
+}

--- a/features/import-with-paths.feature
+++ b/features/import-with-paths.feature
@@ -1,0 +1,44 @@
+Feature: absolute-paths without paths set in tsconfig
+
+Background:
+    Given file "tsconfig.json" is
+        """
+        {
+            "baseDir": ".",
+            "compilerOptions": {
+              "paths": {
+                "components": ["src/nested/components"],
+                "components/*": ["src/nested/components/*"]
+              }
+            },
+            "include": [
+                "./src"
+            ]
+        }
+        """
+
+Scenario: Import component using path aliases for declaration files
+    Given file "./src/nested/components/MyComponent.d.ts" is
+        """
+        export interface MyComponent1 {};
+        export interface UnusedComponent {};
+        """
+    And file "src/b.ts" is
+        """
+        import {MyComponent1} from "components/MyComponent";
+        """
+    When analyzing "tsconfig.json"
+    Then the result is { "src/nested/components/MyComponent.d.ts": ["UnusedComponent"] }
+
+Scenario: Import component using path aliases
+    Given file "./src/nested/components/MyComponent.ts" is
+        """
+        export class MyComponent1 {};
+        export class UnusedComponent {};
+        """
+    And file "src/b.ts" is
+        """
+        import {MyComponent1} from "components/MyComponent";
+        """
+    When analyzing "tsconfig.json"
+    Then the result is { "src/nested/components/MyComponent.ts": ["UnusedComponent"] }

--- a/ispec/run.sh
+++ b/ispec/run.sh
@@ -22,6 +22,10 @@ pushd ../example/definition-files-absolute-paths
 run_itest
 popd
 
+pushd ../example/definition-files-with-paths
+run_itest
+popd
+
 pushd ../example/tsx
 install_and_run_itest
 popd

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -10,7 +10,7 @@ import { isUnique } from './util';
 
 // Parse Imports
 
-const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+const EXTENSIONS = ['.d.ts', '.ts', '.tsx', '.js', '.jsx'];
 
 const relativeTo = (rootDir: string, file: string, path: string): string =>
   relative(rootDir, resolve(dirname(file), path));
@@ -60,6 +60,12 @@ export const extractImport = (decl: ts.ImportDeclaration): FromWhat => {
   };
 };
 
+const declarationFilePatch = (matchedPath: string): string => {
+  return matchedPath.endsWith('.d') && existsSync(`${matchedPath}.ts`)
+    ? matchedPath.slice(0, -2)
+    : matchedPath;
+};
+
 export const addImportCore = (
   fw: FromWhat,
   rootDir: string,
@@ -87,7 +93,7 @@ export const addImportCore = (
             undefined,
             EXTENSIONS,
           ))
-        ? matchedPath.replace(`${baseDir}${sep}`, '')
+        ? declarationFilePatch(matchedPath).replace(`${baseDir}${sep}`, '')
         : undefined;
     }
   };


### PR DESCRIPTION
Workaround for github/travis issue -> replaces #151

* Fix: false positives if importing from a d.ts file, and tsconfig is set to use aliases (paths).