### PR TITLE
Fix --allowUnusedTypes not applying to type re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Updated the chalk dependency (no change in behavior)
 - (Internal) Updated the dev dependencies, involving lot of small changes adding parentheses to lambda parameters.
+- Fix --allowUnusedTypes not applying to type re-exports (Issue #180)
 
 ## [7.0.0] - 11 Nov 2020
 

--- a/features/skip-types.re-exports.feature
+++ b/features/skip-types.re-exports.feature
@@ -1,0 +1,38 @@
+Feature: Skip unused interface or type when re-exporting
+
+Background:
+  Given file "a.ts" is
+    """
+    export interface AInput {
+      x: number;
+      y: number;
+    }
+
+    export type AResult = number
+
+    export const a = ({ x, y }: AInput): AResult => x + y;
+    """
+  And file "b/b.ts" is
+    """
+    export interface BInput {
+      x: number;
+      y: number;
+    }
+
+    export type BResult = number
+
+    export const b = ({ x, y }: BInput): BResult => x + y;
+    """
+  And file "b/index.ts" is
+    """
+    export type { BInput, BResult } from "./b";
+    export { b } from "./b";
+    """
+
+Scenario: Not skipping
+  When analyzing "tsconfig.json"
+  Then the result is { "a.ts": ["AInput", "AResult", "a"], "b/index.ts": ["BInput", "BResult", "b"] }
+
+Scenario: Skipping
+  When analyzing "tsconfig.json" with files ["--allowUnusedTypes"]
+  Then the result is { "a.ts": ["a"], "b/index.ts": ["b"] }

--- a/src/parser/nodeProcessor.ts
+++ b/src/parser/nodeProcessor.ts
@@ -25,8 +25,12 @@ const processExportDeclaration = (
   addImport: (fw: FromWhat) => string | undefined,
   addExport: (exportName: string, node: ts.Node) => void,
   exportNames: string[],
+  extraOptions?: ExtraCommandLineOptions,
 ): void => {
   const exportDecl = node as ts.ExportDeclaration;
+  if (exportDecl.isTypeOnly && extraOptions?.allowUnusedTypes) {
+    return;
+  }
   const { moduleSpecifier } = exportDecl;
   if (moduleSpecifier === undefined) {
     extractExportStatement(exportDecl).forEach((e) => addExport(e, node));
@@ -130,7 +134,13 @@ export const processNode = (
   }
 
   if (kind === ts.SyntaxKind.ExportDeclaration) {
-    processExportDeclaration(node, addImport, addExport, exportNames);
+    processExportDeclaration(
+      node,
+      addImport,
+      addExport,
+      exportNames,
+      extraOptions,
+    );
   }
 
   // Searching for dynamic imports requires inspecting statements in the file,


### PR DESCRIPTION
Kind: patch. Closes #180.

Out of scope: analyzing `export { v, T } from "./x"` and excluding types from such re-exports. Only `export type { T } from "./x"` is covered by this PR.

Using `export type` for re-exporting types is a requirement when `isolatedModules` is set to true ([docs](https://www.typescriptlang.org/docs/handbook/compiler-options.html)). 