### PR TITLE
Fix/issue allow unused types should apply to type re exports 181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Updated the chalk dependency (no change in behavior)
 - (Internal) Updated the dev dependencies, involving lot of small changes adding parentheses to lambda parameters.
 - Fix --allowUnusedTypes not applying to type re-exports (Issue #180)
+- Fix --allowUnusedEnums not applying to enum re-exports
 
 ## [7.0.0] - 11 Nov 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Updated the chalk dependency (no change in behavior)
 - (Internal) Updated the dev dependencies, involving lot of small changes adding parentheses to lambda parameters.
+- Fix --allowUnusedTypes not applying to type re-exports (Issue #180)
 
 ## [7.0.0] - 11 Nov 2020
 

--- a/features/skip-types.re-exports.feature
+++ b/features/skip-types.re-exports.feature
@@ -4,19 +4,21 @@ Background:
   Given file "a.ts" is
     """
     export interface AInput {
-      x: number;
-      y: number;
+    x: number;
+    y: number;
     }
 
     export type AResult = number
+
+    export enum UnusedColorA { Red, Green, Blue};
 
     export const a = ({ x, y }: AInput): AResult => x + y;
     """
   And file "b/b.ts" is
     """
     export interface BInput {
-      x: number;
-      y: number;
+    x: number;
+    y: number;
     }
 
     export type BResult = number
@@ -31,8 +33,12 @@ Background:
 
 Scenario: Not skipping
   When analyzing "tsconfig.json"
-  Then the result is { "a.ts": ["AInput", "AResult", "a"], "b/index.ts": ["BInput", "BResult", "b"] }
+  Then the result is { "a.ts": ["AInput", "AResult", "UnusedColorA", "a"], "b/index.ts": ["BInput", "BResult", "b"] }
 
 Scenario: Skipping
   When analyzing "tsconfig.json" with files ["--allowUnusedTypes"]
-  Then the result is { "a.ts": ["a"], "b/index.ts": ["b"] }
+  Then the result is { "a.ts": ["UnusedColorA", "a"], "b/index.ts": ["b"] }
+
+Scenario: Skipping
+  When analyzing "tsconfig.json" with files ["--allowUnusedEnums"]
+  Then the result is { "a.ts": ["AInput", "AResult", "a"], "b/index.ts": ["BInput", "BResult", "b"] }

--- a/features/skip-types.re-exports.feature
+++ b/features/skip-types.re-exports.feature
@@ -1,39 +1,39 @@
-Feature: Skip unused interface or type when re-exporting
+Feature: Skip unused interface or type or enum when re-exporting
 
 Background:
   Given file "a.ts" is
     """
-    export interface AInput {
+    export interface IAInput {
     x: number;
     y: number;
     }
 
-    export type AResult = number
+    export type TypeAResult = number
 
     export enum UnusedColorA { Red, Green, Blue};
 
-    export const a = ({ x, y }: AInput): AResult => x + y;
+    export const a = ({ x, y }: IAInput): TypeAResult => x + y;
     """
   And file "b/b.ts" is
     """
-    export interface BInput {
+    export interface IBInput {
     x: number;
     y: number;
     }
 
-    export type BResult = number
+    export type TypeBResult = number
 
-    export const b = ({ x, y }: BInput): BResult => x + y;
+    export const b = ({ x, y }: IBInput): TypeBResult => x + y;
     """
   And file "b/index.ts" is
     """
-    export type { BInput, BResult } from "./b";
+    export type { IBInput, TypeBResult } from "./b";
     export { b } from "./b";
     """
 
 Scenario: Not skipping
   When analyzing "tsconfig.json"
-  Then the result is { "a.ts": ["AInput", "AResult", "UnusedColorA", "a"], "b/index.ts": ["BInput", "BResult", "b"] }
+  Then the result is { "a.ts": ["IAInput", "TypeAResult", "UnusedColorA", "a"], "b/index.ts": ["IBInput", "TypeBResult", "b"] }
 
 Scenario: Skipping
   When analyzing "tsconfig.json" with files ["--allowUnusedTypes"]
@@ -41,4 +41,4 @@ Scenario: Skipping
 
 Scenario: Skipping
   When analyzing "tsconfig.json" with files ["--allowUnusedEnums"]
-  Then the result is { "a.ts": ["AInput", "AResult", "a"], "b/index.ts": ["BInput", "BResult", "b"] }
+  Then the result is { "a.ts": ["IAInput", "TypeAResult", "a"], "b/index.ts": ["IBInput", "TypeBResult", "b"] }

--- a/features/skip-types.re-exports.feature
+++ b/features/skip-types.re-exports.feature
@@ -1,0 +1,38 @@
+Feature: Skip unused interface or type when re-exporting
+
+Background:
+  Given file "a.ts" is
+    """
+    export interface AInput {
+      x: number;
+      y: number;
+    }
+
+    export type AResult = number
+
+    export const a = ({ x, y }: AInput): AResult => x + y;
+    """
+  And file "b/b.ts" is
+    """
+    export interface BInput {
+      x: number;
+      y: number;
+    }
+
+    export type BResult = number
+
+    export const b = ({ x, y }: BInput): BResult => x + y;
+    """
+  And file "b/index.ts" is
+    """
+    export type { BInput, BResult } from "./b";
+    export { b } from "./b";
+    """
+
+Scenario: Not skipping
+  When analyzing "tsconfig.json"
+  Then the result is { "a.ts": ["AInput", "AResult", "a"], "b/index.ts": ["BInput", "BResult", "b"] }
+
+Scenario: Skipping
+  When analyzing "tsconfig.json" with files ["--allowUnusedTypes"]
+  Then the result is { "a.ts": ["a"], "b/index.ts": ["b"] }

--- a/src/parser/export.ts
+++ b/src/parser/export.ts
@@ -3,6 +3,8 @@ import * as ts from 'typescript';
 import { ExtraCommandLineOptions, LocationInFile } from '../types';
 import { FromWhat, STAR, getFrom } from './common';
 
+import { TYPE_OR_INTERFACE_NODE_KINDS } from './kinds';
+
 // Parse Exports
 
 const extractAliasFirstFromElements = (
@@ -103,11 +105,6 @@ export const extractExportNames = (path: string, node: ts.Node): string[] => {
   }
 };
 
-const CLASS_OR_INTERFACE_NODE_KINDS = [
-  ts.SyntaxKind.InterfaceDeclaration,
-  ts.SyntaxKind.TypeAliasDeclaration,
-];
-
 const ENUM_NODE_KINDS = [ts.SyntaxKind.EnumDeclaration];
 
 const shouldNodeTypeBeIgnored = (
@@ -119,12 +116,11 @@ const shouldNodeTypeBeIgnored = (
 
   if (allowUnusedTypes && allowUnusedEnums)
     return (
-      CLASS_OR_INTERFACE_NODE_KINDS.includes(node.kind) ||
+      TYPE_OR_INTERFACE_NODE_KINDS.includes(node.kind) ||
       ENUM_NODE_KINDS.includes(node.kind)
     );
 
-  if (allowUnusedTypes)
-    return CLASS_OR_INTERFACE_NODE_KINDS.includes(node.kind);
+  if (allowUnusedTypes) return TYPE_OR_INTERFACE_NODE_KINDS.includes(node.kind);
 
   if (allowUnusedEnums) return ENUM_NODE_KINDS.includes(node.kind);
 

--- a/src/parser/export.ts
+++ b/src/parser/export.ts
@@ -1,9 +1,8 @@
 import * as ts from 'typescript';
 
+import { ENUM_NODE_KINDS, TYPE_OR_INTERFACE_NODE_KINDS } from './kinds';
 import { ExtraCommandLineOptions, LocationInFile } from '../types';
 import { FromWhat, STAR, getFrom } from './common';
-
-import { TYPE_OR_INTERFACE_NODE_KINDS } from './kinds';
 
 // Parse Exports
 
@@ -104,8 +103,6 @@ export const extractExportNames = (path: string, node: ts.Node): string[] => {
     }
   }
 };
-
-const ENUM_NODE_KINDS = [ts.SyntaxKind.EnumDeclaration];
 
 const shouldNodeTypeBeIgnored = (
   node: ts.Node,

--- a/src/parser/kinds.ts
+++ b/src/parser/kinds.ts
@@ -1,0 +1,7 @@
+import * as ts from 'typescript';
+
+export const TYPE_OR_INTERFACE_NODE_KINDS = [
+  ts.SyntaxKind.InterfaceDeclaration,
+  ts.SyntaxKind.TypeAliasDeclaration,
+];
+export const ENUM_NODE_KINDS = [ts.SyntaxKind.EnumDeclaration];

--- a/src/parser/nodeProcessor.ts
+++ b/src/parser/nodeProcessor.ts
@@ -4,11 +4,12 @@ import { ExtraCommandLineOptions, Imports } from '../types';
 import { FromWhat, STAR } from './common';
 import { addDynamicImports, mayContainDynamicImports } from './dynamic';
 import {
-  extractExportNames,
   extractExportFromImport,
+  extractExportNames,
   extractExportStatement,
 } from './export';
 
+import { ENUM_NODE_KINDS } from './kinds';
 import { addImportsFromNamespace } from './imports-from-namespace';
 import { extractImport } from './import';
 import { namespaceBlacklist } from './namespaceBlacklist';
@@ -28,7 +29,11 @@ const processExportDeclaration = (
   extraOptions?: ExtraCommandLineOptions,
 ): void => {
   const exportDecl = node as ts.ExportDeclaration;
-  if (exportDecl.isTypeOnly && extraOptions?.allowUnusedTypes) {
+  if (
+    (exportDecl.isTypeOnly && extraOptions?.allowUnusedTypes) ||
+    (ENUM_NODE_KINDS.includes(exportDecl.kind) &&
+      extraOptions?.allowUnusedEnums)
+  ) {
     return;
   }
   const { moduleSpecifier } = exportDecl;

--- a/src/parser/nodeProcessor.ts
+++ b/src/parser/nodeProcessor.ts
@@ -25,8 +25,12 @@ const processExportDeclaration = (
   addImport: (fw: FromWhat) => string | undefined,
   addExport: (exportName: string, node: ts.Node) => void,
   exportNames: string[],
+  extraOptions?: ExtraCommandLineOptions,
 ): void => {
   const exportDecl = node as ts.ExportDeclaration;
+  if (exportDecl.isTypeOnly && extraOptions?.allowUnusedTypes) {
+    return;
+  }
   const { moduleSpecifier } = exportDecl;
   if (moduleSpecifier === undefined) {
     extractExportStatement(exportDecl).forEach((e) => addExport(e, node));
@@ -130,7 +134,13 @@ export const processNode = (
   }
 
   if (kind === ts.SyntaxKind.ExportDeclaration) {
-    processExportDeclaration(node, addImport, addExport, exportNames);
+    processExportDeclaration(
+      node,
+      addImport,
+      addExport,
+      exportNames,
+      extraOptions,
+    );
   }
 
   // Searching for dynamic imports requires inspecting statements in the file,


### PR DESCRIPTION
Fix issues:

- allow unused types should apply to type re exports - Fixes #180
- allow unused enums should apply to enum re exports

Using code from https://github.com/pzavolinsky/ts-unused-exports/pull/181

Thank you to @kachkaev !
