### PR TITLE
Add ko-fi donate button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![Dependencies](https://david-dm.org/pzavolinsky/ts-unused-exports.svg)](https://david-dm.org/pzavolinsky/ts-unused-exports)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/Z8Z13CHUI)
+
 ## Installation
 
 ```


### PR DESCRIPTION
Adds a ko-fi donate button, that points to a new ko-fi account I created, especially for ts-unused-exports:

https://ko-fi.com/tsunusedexports

Currently, it is setup to point to my own PayPal account.

BUT any donations will show up in the public feed of ko-fi.

@pzavolinsky hope this is okay? let's see how it goes!
