### PR TITLE
normalize path separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [7.0.1] - 18 Jan 2021
+### Changed
+
+- Fix false positives on Windows machines when using absolute paths (baseUrl) or aliases (paths).
 
 ### Changed
 

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -99,9 +99,11 @@ export const addImportCore = (
       ) {
         const absoluteRootDir = resolve(rootDir);
 
-        return declarationFilePatch(matchedPath)
-          .replace(`${absoluteRootDir}${sep}`, '')
-          .replace(`${baseDir}${sep}`, '');
+        return join(
+          declarationFilePatch(matchedPath)
+            .replace(`${absoluteRootDir}${sep}`, '')
+            .replace(`${baseDir}${sep}`, ''),
+        );
       }
 
       return from;

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -99,6 +99,7 @@ export const addImportCore = (
       ) {
         const absoluteRootDir = resolve(rootDir);
 
+        // normalizing path separators as tsconfig-path can return mixed path separators
         return join(
           declarationFilePatch(matchedPath)
             .replace(`${absoluteRootDir}${sep}`, '')


### PR DESCRIPTION
It looks like when using windows you can sometimes get both styles of path separators making the usage logic not work as it assumes all path separators are the same.

IE.
from tsconfigPathsMatcher
`...\src\lib\polyfill\ie_edge/ie11`
after replace
`src\lib\polyfill\ie_edge/ie11`

I just add a path.join to normalize the path separators.

Here is the relevant code in tsconfig-paths
https://github.com/dividab/tsconfig-paths/blob/c4ca84c0968680db11a6e10d9ebcdda220255575/src/try-path.ts#L41
all 'file' and 'extension' paths will have a mixed path separators because these are the only tryPath that does not use `path.join`