### PR TITLE
Fix/issue support tsconfig extends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Changed
+
+- Fix: Add support for 'extends' in tsconfig.json (Issue #102, #200)
+
 ## [7.0.3] - 25 Feb 2021
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+## [8.0.0] - [<release date>]
+
 ### Changed
 
 - Fix: Add support for 'extends' in tsconfig.json (Issue #102, #200)
+- (Internal) Using absolute paths which is less ambiguous. Delegating tsconfig.json parsing to TypeScript.
 
 ## [7.0.3] - 25 Feb 2021
 

--- a/example/definition-files-absolute-paths/src/MyClass.ts
+++ b/example/definition-files-absolute-paths/src/MyClass.ts
@@ -1,0 +1,1 @@
+export class MyClass {}

--- a/example/definition-files-absolute-paths/src/main.ts
+++ b/example/definition-files-absolute-paths/src/main.ts
@@ -1,3 +1,4 @@
 import { Model } from 'models';
+import { MyClass } from 'MyClass';
 
 export class UnusedClassFromMain implements Model {}

--- a/example/with-paths/tsconfig.base.json
+++ b/example/with-paths/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "paths": {
+      "utils": ["utils/src"],
       "utils/*": ["utils/src/*"]
     }
   }

--- a/example/with-paths/tsconfig.base.json
+++ b/example/with-paths/tsconfig.base.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "utils/*": ["utils/src/*"]
+    }
+  }
+}

--- a/example/with-paths/tsconfig.json
+++ b/example/with-paths/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends":"./tsconfig.base.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es5",
@@ -7,8 +7,5 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "moduleResolution": "node",
-    "paths": {
-      "utils": ["utils/src"]
-    }
   }
 }

--- a/example/with-paths/tsconfig.json
+++ b/example/with-paths/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends":"./tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es5",
@@ -7,8 +8,7 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
     "paths": {
-      "utils": ["utils/src"],
-      "utils/*": ["utils/src/*"]
+      "utils": ["utils/src"]
     }
   }
 }

--- a/features/ignore-imports-from.feature
+++ b/features/ignore-imports-from.feature
@@ -72,7 +72,7 @@ Scenario: Ignoring all non-test files, with test-utils files
 
 # Only evaluate *test* files (ignore all non-test files).
 # - using --ignoreProductionFiles
-Scenario: Ignoring all non-test files, with test-utils files
+Scenario: Ignoring all non-test files, with test-utils files via ignoreProductionFiles
   Given file "TestUtils.ts" is
     """
     export function helpTest() {}";

--- a/package-lock.json
+++ b/package-lock.json
@@ -3324,9 +3324,9 @@
       }
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yargs": {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -4,8 +4,7 @@ import {
   File,
   LocationInFile,
 } from './types';
-
-import { removeExportStarPrefix } from './parser/util';
+import { indexCandidates, removeExportStarPrefix } from './parser/util';
 
 export { Analysis } from './types';
 
@@ -74,7 +73,6 @@ const processImports = (file: File, exportMap: ExportMap): void => {
 
     // Handle imports from an index file
     if (!ex && key === '.') {
-      const indexCandidates = ['index', 'index.ts', 'index.tsx'];
       for (let c = 0; c < indexCandidates.length; c++) {
         const indexKey = indexCandidates[c];
         ex = exportMap[indexKey]?.exports || undefined;

--- a/src/app.ts
+++ b/src/app.ts
@@ -59,8 +59,5 @@ export default (tsconfigPath: string, files?: string[]): Analysis => {
   const args = extractOptionsFromFiles(files);
   const tsConfig = loadTsConfig(tsconfigPath, args.tsFiles);
 
-  return analyze(
-    parseFiles(dirname(tsconfigPath), tsConfig, args.options),
-    args.options,
-  );
+  return analyze(parseFiles(tsConfig, args.options), args.options);
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,12 +24,14 @@ const parseTsConfig = (tsconfigPath: string): TsConfig => {
       configFile.config,
       ts.sys,
       basePath,
+      undefined,
+      tsconfigPath,
     );
     if (result.errors.length) throw result.errors;
 
     return {
-      baseUrl: result.raw?.compilerOptions?.baseUrl || '.',
-      paths: result.raw?.compilerOptions?.paths,
+      baseUrl: result.raw?.compilerOptions?.baseUrl || '.', // TODO - use result.options.baseUrl but that seems to require changes (simplicifications?) elsewhere
+      paths: result.options.paths,
       files: result.fileNames,
     };
   } catch (e) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,8 +29,11 @@ const parseTsConfig = (tsconfigPath: string): TsConfig => {
     );
     if (result.errors.length) throw result.errors;
 
+    // We now use absolute paths to avoid ambiguity and to be able to delegate baseUrl resolving to TypeScript.
+    // A consequence is, we cannot fall back to '.' so instead the fallback is the tsconfig dir:
+    // (I think this only occurs with unit tests!)
     return {
-      baseUrl: result.raw?.compilerOptions?.baseUrl || '.', // TODO - use result.options.baseUrl but that seems to require changes (simplicifications?) elsewhere
+      baseUrl: result.options.baseUrl || basePath,
       paths: result.options.paths,
       files: result.fileNames,
     };

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,21 +6,22 @@ import { dirname, resolve } from 'path';
 import { TsConfig } from './types';
 import { extractOptionsFromFiles } from './argsParser';
 import parseFiles from './parser';
-import { readFileSync } from 'fs';
 
 const parseTsConfig = (tsconfigPath: string): TsConfig => {
   const basePath = resolve(dirname(tsconfigPath));
 
   try {
-    const parseJsonResult = ts.parseConfigFileTextToJson(
+    const configFileName = ts.findConfigFile(
+      basePath,
+      ts.sys.fileExists,
       tsconfigPath,
-      readFileSync(tsconfigPath, { encoding: 'utf8' }),
     );
+    if (!configFileName) throw `Couldn't find ${tsconfigPath}`;
 
-    if (parseJsonResult.error) throw parseJsonResult.error;
+    const configFile = ts.readConfigFile(configFileName, ts.sys.readFile);
 
     const result = ts.parseJsonConfigFileContent(
-      parseJsonResult.config,
+      configFile.config,
       ts.sys,
       basePath,
     );

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -14,9 +14,6 @@ import path = require('path');
 
 const EXTENSIONS = ['.d.ts', '.ts', '.tsx', '.js', '.jsx'];
 
-const relativeTo = (file: string, path: string): string =>
-  resolve(dirname(file), path);
-
 const isRelativeToBaseDir = (baseDir: string, from: string): boolean =>
   existsSync(resolve(baseDir, `${from}.js`)) ||
   existsSync(resolve(baseDir, `${from}.ts`)) ||
@@ -86,7 +83,7 @@ export const addImportCore = (
   const getKey = (from: string): string => {
     if (from[0] == '.') {
       // An undefined return indicates the import is from 'index.ts' or similar == '.'
-      return relativeTo(pathIn, from) || '.';
+      return resolve(dirname(pathIn), from) || '.';
     } else {
       let matchedPath;
 

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -14,7 +14,7 @@ import path = require('path');
 
 const EXTENSIONS = ['.d.ts', '.ts', '.tsx', '.js', '.jsx'];
 
-const relativeTo = (rootDir: string, file: string, path: string): string =>
+const relativeTo = (file: string, path: string): string =>
   resolve(dirname(file), path);
 
 const isRelativeToBaseDir = (baseDir: string, from: string): boolean =>
@@ -70,28 +70,22 @@ const declarationFilePatch = (matchedPath: string): string => {
 
 export const addImportCore = (
   fw: FromWhat,
-  rootDir: string,
   pathIn: string,
   imports: Imports,
-  baseDir: string,
   baseUrl: string,
   tsconfigPathsMatcher?: tsconfigPaths.MatchPath,
 ): string | undefined => {
   const { from, what } = fw;
 
-  // xxx redundant params!
-  // baseDir, baseUrl are same
-  // rootDir is always .
-
   const getKey = (from: string): string => {
     if (from[0] == '.') {
       // An undefined return indicates the import is from 'index.ts' or similar == '.'
-      return relativeTo(rootDir, pathIn, from) || '.';
+      return relativeTo(pathIn, from) || '.';
     } else {
       let matchedPath;
 
-      if (isRelativeToBaseDir(baseDir, from)) {
-        if (!from.startsWith(baseUrl)) return path.join(baseUrl, from);
+      if (isRelativeToBaseDir(baseUrl, from)) {
+        if (!from.startsWith(baseUrl)) return path.join(baseUrl, from); // xxx dupe
 
         return from;
       }
@@ -112,7 +106,7 @@ export const addImportCore = (
         return matched;
       }
 
-      if (!from.startsWith(baseUrl)) return path.join(baseUrl, from);
+      if (!from.startsWith(baseUrl)) return path.join(baseUrl, from); // xxx dupe
 
       return from;
     }

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -107,7 +107,8 @@ export const addImportCore = (
 
         if (!matched.startsWith(baseUrl)) return path.join(baseUrl, matched);
 
-        return matched;
+        // Use join to normalize path separators, since tsconfig-path can return mixed path separators (Windows)
+        return path.join(matched);
       }
 
       return joinWithBaseUrl(baseUrl, from);

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -26,6 +26,12 @@ const isRelativeToBaseDir = (baseDir: string, from: string): boolean =>
   existsSync(resolve(baseDir, from, 'index.ts')) ||
   existsSync(resolve(baseDir, from, 'index.tsx'));
 
+const joinWithBaseUrl = (baseUrl: string, from: string) => {
+  if (!from.startsWith(baseUrl)) return path.join(baseUrl, from);
+
+  return from;
+};
+
 export const extractImport = (decl: ts.ImportDeclaration): FromWhat => {
   const from = getFrom(decl.moduleSpecifier);
   const { importClause } = decl;
@@ -85,9 +91,7 @@ export const addImportCore = (
       let matchedPath;
 
       if (isRelativeToBaseDir(baseUrl, from)) {
-        if (!from.startsWith(baseUrl)) return path.join(baseUrl, from); // xxx dupe
-
-        return from;
+        return joinWithBaseUrl(baseUrl, from);
       }
 
       if (
@@ -106,9 +110,7 @@ export const addImportCore = (
         return matched;
       }
 
-      if (!from.startsWith(baseUrl)) return path.join(baseUrl, from); // xxx dupe
-
-      return from;
+      return joinWithBaseUrl(baseUrl, from);
     }
   };
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -47,7 +47,6 @@ const pathWithoutExtension = (pathIn: string): string => {
 };
 
 const mapFile = (
-  rootDir: string,
   path: string,
   file: ts.SourceFile,
   baseUrl: string,
@@ -58,20 +57,11 @@ const mapFile = (
   const exportNames: string[] = [];
   const exportLocations: LocationInFile[] = [];
 
-  const baseDir = baseUrl; // xxx remove baseDir
   const tsconfigPathsMatcher =
-    (!!paths && tsconfigPaths.createMatchPath(baseDir, paths)) || undefined;
+    (!!paths && tsconfigPaths.createMatchPath(baseUrl, paths)) || undefined;
 
   const addImport = (fw: FromWhat): string | undefined => {
-    return addImportCore(
-      fw,
-      rootDir,
-      path,
-      imports,
-      baseDir,
-      baseUrl,
-      tsconfigPathsMatcher,
-    );
+    return addImportCore(fw, path, imports, baseUrl, tsconfigPathsMatcher);
   };
 
   const addExport = (exportName: string, node: ts.Node): void => {
@@ -111,14 +101,12 @@ const mapFile = (
 };
 
 const parseFile = (
-  rootDir: string,
   path: string,
   baseUrl: string,
   paths?: TsConfigPaths,
   extraOptions?: ExtraCommandLineOptions,
 ): File =>
   mapFile(
-    rootDir,
     path,
     ts.createSourceFile(
       path,
@@ -132,7 +120,6 @@ const parseFile = (
   );
 
 const parsePaths = (
-  rootDir: string,
   { baseUrl, files: filePaths, paths }: TsConfig,
   extraOptions?: ExtraCommandLineOptions,
 ): File[] => {
@@ -140,17 +127,14 @@ const parsePaths = (
 
   const files = filePaths
     .filter((p) => includeDeclarationFiles || !p.includes('.d.'))
-    .map((path) =>
-      parseFile(rootDir, resolve(rootDir, path), baseUrl, paths, extraOptions),
-    );
+    .map((path) => parseFile(resolve('.', path), baseUrl, paths, extraOptions));
 
   return files;
 };
 
 export default (
-  rootDir: string,
   TsConfig: TsConfig,
   extraOptions?: ExtraCommandLineOptions,
 ): File[] => {
-  return parsePaths(rootDir, TsConfig, extraOptions);
+  return parsePaths(TsConfig, extraOptions);
 };

--- a/src/parser/util.ts
+++ b/src/parser/util.ts
@@ -6,6 +6,8 @@ export function isUnique<T>(value: T, index: number, self: T[]): boolean {
   return self.indexOf(value) === index;
 }
 
+export const indexCandidates = ['index', 'index.ts', 'index.tsx', 'index.js'];
+
 export function removeExportStarPrefix(path: string): string {
   if (path.startsWith('*:')) return path.slice(2);
   else if (path.startsWith('*as:')) return path.slice(4);


### PR DESCRIPTION
Adds support for "extends" property in the tsconfig.json, so the relevant properties are read from base configs as appropriate (via TypeScript).

Internal: uses absolute paths which is less ambiguous in case a project has different types with same local paths.

---

A continuation of #200 (mainly due to Travis issue)

Possibly would solve #102 

---


* [x] add itest that shows extends is not working
* [x] add proper support for extends ('paths')
* [x] add support for reading baseUrl from extends

ref = https://github.com/microsoft/TypeScript/issues/18865
ref = https://npm.io/search/keyword:tsconfig
