### PR TITLE
Build/fix selection of typescript version

### DIFF
--- a/.github/workflows/node.js.deploy.yml
+++ b/.github/workflows/node.js.deploy.yml
@@ -4,8 +4,7 @@ name: Deploy to npm
 #
 # Also runs the full set of tests, with all Node + TypeScript versions.
 
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   build_test_and_deploy:
@@ -25,7 +24,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       # npm ci - for a clean install, fails safe
       - run: npm ci
-      - run: npm install --development ${{ matrix.typescript-version }}
+      - run: npm install --development typescript@${{ matrix.typescript-version }}
       - run: npm test
       # only deploy to npmjs, if this is master AND this is one particular build (we only want to deploy once!)
       - name: Deploy

--- a/.github/workflows/node.js.deploy.yml
+++ b/.github/workflows/node.js.deploy.yml
@@ -28,7 +28,8 @@ jobs:
       - run: npm test
       # only deploy to npmjs, if this is master AND this is one particular build (we only want to deploy once!)
       - name: Deploy
-        if: github.ref == 'refs/heads/master' && matrix.node-version == '16.x' && matrix.typescript-version == '4'
+        # use node 14 because 16+ uses package-lock.json version 2
+        if: github.ref == 'refs/heads/master' && matrix.node-version == '14.x' && matrix.typescript-version == '4'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,10 +6,10 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
 
 jobs:
   build:
@@ -29,7 +29,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       # npm ci - for a clean install, fails safe
       - run: npm ci
-      - run: npm install --development ${{ matrix.typescript-version }}
+      - run: npm install --development typescript@${{ matrix.typescript-version }}
       - run: npm test
       # - name: Report Code Coverage
       #   if: matrix.node-version == '16.x' && matrix.typescript-version == 4


### PR DESCRIPTION
Fixes to the 2 workflows:

- add missing package name `typescript` (else installs bogus package like 3 or 4)
- deploy to npm via Node 14 (not 16, because that re-writes the package-lock.json to version 2)