### PR TITLE
Fix an ESM index.js/.mjs/.cjs import edge case

### DIFF
--- a/features/index.feature
+++ b/features/index.feature
@@ -18,6 +18,24 @@ Scenario: Import './index'
   When analyzing "tsconfig.json"
   Then the result is {}
 
+Scenario: Import './index.js'
+  Given file "index.ts" is export const a = 1;
+  And file "a.ts" is import { a } from './index.js';
+  When analyzing "tsconfig.json"
+  Then the result is {}
+
+Scenario: Import './index.mjs'
+  Given file "index.mts" is export const a = 1;
+  And file "a.ts" is import { a } from './index.mjs';
+  When analyzing "tsconfig.json"
+  Then the result is {}
+
+Scenario: Import './index.cjs'
+  Given file "index.cts" is export const a = 1;
+  And file "a.ts" is import { a } from './index.cjs';
+  When analyzing "tsconfig.json"
+  Then the result is {}
+
 Scenario: Import './index' TSX
   Given file "index.tsx" is export const a = 1;
   And file "a.ts" is import { a } from './index';

--- a/src/parser/common.ts
+++ b/src/parser/common.ts
@@ -11,7 +11,7 @@ export interface FromWhat {
 const TRIM_QUOTES = /^['"](.*)['"]$/;
 
 export const getFromText = (moduleSpecifier: string): string =>
-  moduleSpecifier.replace(TRIM_QUOTES, '$1').replace(/\/index$/, '');
+  moduleSpecifier.replace(TRIM_QUOTES, '$1').replace(/\/index(.[mc]?js)?$/, '');
 
 export const getFrom = (moduleSpecifier: ts.Expression): string =>
   getFromText(moduleSpecifier.getText());


### PR DESCRIPTION
In [1] a removeFileExtensionToAllowForJs() utility function has been added to help with normalizing import paths into extensionless ones in order to handle ESM imports (which have to have extensions, either .js, .mjs or .cjs).

One thing was missed though as index files are handled in a special way.

In the analyzer.ts:

    const processImports = (file: File, exportMap: ExportMap): void => {
      Object.keys(file.imports).forEach((key) => {
        let ex = exportMap[removeFileExtensionToAllowForJs(key)]?.exports;

exportMap had keys with extensions and "index" removed (so that "xxx/index.ts" became "xxx" there) but paths in file.imports came from getFromText() which only handled extensionless index imports so xxx/index.js" stayed "xxx/index.js". The .js extension was then removed by removeFileExtensionToAllowForJs() but the damage was done already and "xxx" != "xxx/index".

This change brings the removeFileExtensionToAllowForJs()-like ESM-compatible behavior to getFromText().

[1] 6e506ae05ef3 ("Add .js extension support with es6 example (#255)")