### PR TITLE
Stop extra semicolons in exclude paths from preventing results

### DIFF
--- a/features/exclude-paths-from-report.feature
+++ b/features/exclude-paths-from-report.feature
@@ -16,3 +16,8 @@ Scenario: Ignore none
   Given file "exports.ts" is export const a = 1;
   When analyzing "tsconfig.json" with files ["--excludePathsFromReport=other-1;other-2"]
   Then the result is { "exports.ts": ["a"] }
+
+Scenario: Extra semi-colons doesn't filter all results
+  Given file "exports.ts" is export const a = 1;
+  When analyzing "tsconfig.json" with files ["--excludePathsFromReport=other-1;;other-2;"]
+  Then the result is { "exports.ts": ["a"] }

--- a/src/argsParser.ts
+++ b/src/argsParser.ts
@@ -43,7 +43,9 @@ function processOptions(
         {
           const paths = optionValue.split(';');
           paths.forEach((path) => {
-            pathsToExcludeFromReport.push(path);
+            if (path) {
+              pathsToExcludeFromReport.push(path);
+            }
           });
         }
         break;


### PR DESCRIPTION
**Problem**
We have a list of several paths that we exclude from a report. Recently someone added a new path and left a trailing semi-colon (i.e. `--excludePathsFromReport=scripts;jobs;`). It turns out this will entirely disable the tool and prevent any results from being output.

**Solution**
Parse out empty or null arguments from being grabbed as args.

Thanks for the tool though, I appreciate it! Now I'm off to fix all the extra exports people introduced in the meantime 😂