### PR TITLE
Fix issue with ignoreLocallyUsed

### DIFF
--- a/features/ignore-locally-used.feature
+++ b/features/ignore-locally-used.feature
@@ -40,3 +40,26 @@ Scenario: ignoreLocallyUsed works with more complex file extensions
     """
   When running ts-unused-exports "tsconfig.json" --ignoreLocallyUsed
   Then the CLI result at status is 0
+
+Scenario: ignoreLocallyUsed works with template literals
+  Given file "local.test.ts" is
+    """
+    export const a = 1;
+    const b = `text ${a} some more text`;
+    """
+  When running ts-unused-exports "tsconfig.json" --ignoreLocallyUsed
+  Then the CLI result at status is 0
+
+Scenario: ignoreLocallyUsed works with objects
+  Given file "local.test.ts" is
+    """
+    export const a = 1;
+    export const b = 2;
+    const c = {
+      a
+    };
+    c['b'] = b;
+    """
+  When running ts-unused-exports "tsconfig.json" --ignoreLocallyUsed
+  Then the CLI result at status is 0
+  

--- a/src/parser/nodeProcessor.ts
+++ b/src/parser/nodeProcessor.ts
@@ -161,12 +161,7 @@ export const processNode = (
     addImportsFromNamespace(node, imports, addImport);
   }
 
-  if (
-    extraOptions?.ignoreLocallyUsed &&
-    kind === ts.SyntaxKind.Identifier &&
-    node.parent.kind !== ts.SyntaxKind.VariableDeclaration &&
-    node.parent.kind !== ts.SyntaxKind.FunctionDeclaration
-  ) {
+  if (extraOptions?.ignoreLocallyUsed && kind === ts.SyntaxKind.Identifier) {
     addImport({
       from: removeTsFileExtension(node.getSourceFile().fileName),
       what: [node.getText()],


### PR DESCRIPTION
Annoyingly I don't remember why I included the logic around the parent node kind originally, but I came across some false positives whilst using this with `--ignoreLocallyUsed` in a large codebase today and removing that logic resolves the issue