### PR TITLE
Support check only files for libraries

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -268,13 +268,16 @@ const makeExportStarRelativeForPresentation = (
 
 export default (
   files: File[],
+  checkOnlyFiles: File[],
   extraOptions?: ExtraCommandLineOptions & ExtraOptionsForPresentation,
 ): Analysis => {
   const filteredFiles = filterFiles(files, extraOptions);
 
   const exportMap = getExportMap(filteredFiles);
   expandExportFromStar(filteredFiles, exportMap);
-  filteredFiles.forEach((file) => processImports(file, exportMap));
+  [...filteredFiles, ...checkOnlyFiles].forEach((file) =>
+    processImports(file, exportMap),
+  );
 
   const analysis: Analysis = { unusedExports: {} };
   const unusedFiles: string[] = [];

--- a/src/app.ts
+++ b/src/app.ts
@@ -61,11 +61,20 @@ export const analyzeTsConfig = (
   files?: string[],
 ): Analysis => {
   const args = extractOptionsFromFiles(files);
-  const tsConfig = loadTsConfig(tsconfigPath, args.tsFiles);
+  const tsConfig = loadTsConfig(
+    tsconfigPath,
+    args.options?.onlyCheckInputFiles ? args.tsFiles : [],
+  );
+
+  const normalFiles = parseFiles(tsConfig, args.options);
+
+  const checkOnlyFiles = args.options?.onlyCheckInputFiles
+    ? parseFiles({ ...tsConfig, files: args.tsFiles ?? [] }, args.options)
+    : [];
 
   const options = {
     ...args.options,
     baseUrl: tsConfig.baseUrl,
   };
-  return analyze(parseFiles(tsConfig, args.options), options);
+  return analyze(normalFiles, checkOnlyFiles, options);
 };

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -110,7 +110,7 @@ const parseFile = (
       path,
       readFileSync(path, { encoding: 'utf8' }),
       ts.ScriptTarget.ES2015,
-      /*setParentNodes */ true,
+      /* setParentNodes */ true,
     ),
     baseUrl,
     paths,

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export interface TsConfig {
   baseUrl: string;
   paths?: TsConfigPaths;
   files: string[];
+  checkOnlyFiles?: string[];
 }
 
 export interface ExtraCommandLineOptions {
@@ -59,6 +60,7 @@ export interface ExtraCommandLineOptions {
   showLineNumber?: boolean;
   silent?: boolean;
   findCompletelyUnusedFiles?: boolean;
+  onlyCheckInputFiles?: boolean;
 }
 
 export interface ExtraOptionsForPresentation {


### PR DESCRIPTION
We want to check a projects imports' against both itself and additional files, but do not want to include those additional files' exports in the check. This is useful for people who have split up code into various libraries (which is our use case) and want to check for unused exports/code. This change achieves this.