### PR TITLE
feat : allow comments after ts unused exports disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [11.0.2] - 18 March 2024
+
+### Changed
+
+- allow adding comments after "// ts-unused-exports:disable-next-line" to explain the reason of the ignore
+
 ## [11.0.1] - 25 Nov 2024
 
 ### Changed

--- a/features/misc.feature
+++ b/features/misc.feature
@@ -32,3 +32,13 @@ Scenario: Disable with comments
     """
   When analyzing "tsconfig.json"
   Then the result is { "unusedExports": { "a.ts": ["b"] } }
+
+Scenario: Disable with comments with explanation
+Given file "a.ts" is
+    """
+    // ts-unused-exports:disable-next-line because some good reason
+    export const a = 1;
+    export const b = 1;
+    """
+  When analyzing "tsconfig.json"
+  Then the result is { "unusedExports": { "a.ts": ["b"] } }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-unused-exports",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "ts-unused-exports finds unused exported symbols in your Typescript project",
   "main": "lib/app.js",
   "repository": {

--- a/src/parser/comment.ts
+++ b/src/parser/comment.ts
@@ -16,7 +16,7 @@ export const isNodeDisabledViaComment = (
     const commentText = file
       .getFullText()
       .substring(commentRange.pos, commentRange.end);
-    if (commentText === '// ts-unused-exports:disable-next-line') {
+    if (commentText.startsWith('// ts-unused-exports:disable-next-line')) {
       return true;
     }
   }


### PR DESCRIPTION
Allow adding comments after `ts-unused-exports:disable-next-line` to explain why a particular export is unused.

For example :

```ts
// ts-unused-exports:disable-next-line because some good reason
export const helperDebugFunctionThatWeOftenDontUse = () => {};
```